### PR TITLE
Add Vue 3 component library template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# uitest-library
+# ui-library
+
+This repository contains a simple Vue 3 component library.
+See the `ui-library` directory for source code and instructions.

--- a/ui-library/.gitignore
+++ b/ui-library/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/ui-library/README.md
+++ b/ui-library/README.md
@@ -1,0 +1,42 @@
+# ui-library
+
+Reusable Vue 3 component library built with Vite, Tailwind CSS and TypeScript.
+
+## Installation
+
+```bash
+npm install ui-library
+```
+
+Add Tailwind CSS styles in your project:
+
+```ts
+// main.ts
+import 'ui-library/theme/index.css'
+```
+
+## Usage
+
+```ts
+import { BaseButton, BaseInput } from 'ui-library'
+```
+
+```vue
+<template>
+  <BaseButton variant="primary">Click me</BaseButton>
+  <BaseInput v-model="text" />
+</template>
+```
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/ui-library/components/BaseButton.vue
+++ b/ui-library/components/BaseButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <button
+    :class="[
+      'font-medium rounded transition focus:outline-none',
+      sizes[size],
+      variants[variant],
+      { 'opacity-50 cursor-not-allowed': disabled }
+    ]"
+    :disabled="disabled"
+    v-bind="$attrs"
+  >
+    <slot />
+  </button>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+
+interface Props {
+  variant?: 'primary' | 'secondary' | 'danger'
+  size?: 'sm' | 'md' | 'lg'
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'primary',
+  size: 'md',
+  disabled: false,
+})
+
+const variants = {
+  primary: 'bg-brand text-white hover:bg-brand-dark',
+  secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+}
+
+const sizes = {
+  sm: 'px-2 py-1 text-sm',
+  md: 'px-4 py-2',
+  lg: 'px-6 py-3 text-lg',
+}
+</script>

--- a/ui-library/components/BaseInput.vue
+++ b/ui-library/components/BaseInput.vue
@@ -1,0 +1,53 @@
+<template>
+  <input
+    :class="[
+      'border rounded w-full focus:outline-none focus:ring-2',
+      sizes[size],
+      variants[variant],
+      { 'opacity-50 cursor-not-allowed bg-gray-100': disabled }
+    ]"
+    :disabled="disabled"
+    :type="type"
+    v-model="inputValue"
+    v-bind="$attrs"
+  />
+</template>
+
+<script lang="ts" setup>
+import { ref, watch, defineProps, defineEmits, withDefaults } from 'vue'
+
+interface Props {
+  modelValue?: string | number
+  variant?: 'default' | 'underline'
+  size?: 'sm' | 'md' | 'lg'
+  type?: string
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'default',
+  size: 'md',
+  type: 'text',
+  disabled: false,
+})
+const emit = defineEmits(['update:modelValue'])
+
+const inputValue = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  val => (inputValue.value = val)
+)
+watch(inputValue, val => emit('update:modelValue', val))
+
+const variants = {
+  default: 'border-gray-300 focus:ring-brand',
+  underline: 'border-0 border-b border-gray-300 focus:ring-0 focus:border-brand',
+}
+
+const sizes = {
+  sm: 'px-2 py-1 text-sm',
+  md: 'px-3 py-2',
+  lg: 'px-4 py-3 text-lg',
+}
+</script>

--- a/ui-library/components/BaseModal.vue
+++ b/ui-library/components/BaseModal.vue
@@ -1,0 +1,48 @@
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-center justify-center"
+  >
+    <div class="absolute inset-0 bg-black opacity-50" @click="close"></div>
+    <div :class="['bg-white rounded shadow-lg z-10', sizes[size]]" role="dialog">
+      <header class="border-b p-4">
+        <slot name="header">Modal</slot>
+      </header>
+      <section class="p-4">
+        <slot />
+      </section>
+      <footer class="border-t p-4 text-right">
+        <slot name="footer">
+          <BaseButton @click="close">Close</BaseButton>
+        </slot>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { defineProps, defineEmits, withDefaults } from 'vue'
+import BaseButton from './BaseButton.vue'
+
+interface Props {
+  modelValue: boolean
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 'md',
+})
+const emit = defineEmits(['update:modelValue'])
+
+const open = props.modelValue
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+const sizes = {
+  sm: 'max-w-sm w-full',
+  md: 'max-w-md w-full',
+  lg: 'max-w-lg w-full',
+}
+</script>

--- a/ui-library/components/BaseTable.vue
+++ b/ui-library/components/BaseTable.vue
@@ -1,0 +1,16 @@
+<template>
+  <table class="min-w-full divide-y divide-gray-200" v-bind="$attrs">
+    <thead class="bg-gray-50">
+      <tr>
+        <slot name="head" />
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-200">
+      <slot />
+    </tbody>
+  </table>
+</template>
+
+<script lang="ts" setup>
+// no props for now
+</script>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,0 +1,4 @@
+export { default as BaseButton } from './components/BaseButton.vue'
+export { default as BaseInput } from './components/BaseInput.vue'
+export { default as BaseModal } from './components/BaseModal.vue'
+export { default as BaseTable } from './components/BaseTable.vue'

--- a/ui-library/package.json
+++ b/ui-library/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ui-library",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/ui-library.umd.js",
+  "module": "dist/ui-library.es.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "theme"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/ui-library.es.js",
+      "require": "./dist/ui-library.umd.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --declaration --emitDeclarationOnly --outDir dist && vite build"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vue": "^3.0.0",
+    "vue-tsc": "^1.0.0"
+  }
+}

--- a/ui-library/postcss.config.js
+++ b/ui-library/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: { config: './theme/tailwind.config.js' },
+    autoprefixer: {},
+  },
+}

--- a/ui-library/theme/index.css
+++ b/ui-library/theme/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/ui-library/theme/tailwind.config.js
+++ b/ui-library/theme/tailwind.config.js
@@ -1,0 +1,32 @@
+import { defineConfig } from 'tailwindcss/helpers'
+
+export default defineConfig({
+  content: [],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          light: '#3AB0FF',
+          DEFAULT: '#0080FF',
+          dark: '#005BBB',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+      },
+      borderRadius: {
+        sm: '0.125rem',
+        DEFAULT: '0.25rem',
+        lg: '0.5rem',
+        full: '9999px',
+      },
+      spacing: {
+        18: '4.5rem',
+      },
+      boxShadow: {
+        outline: '0 0 0 3px rgba(0, 128, 255, 0.5)',
+      },
+    },
+  },
+  plugins: [],
+})

--- a/ui-library/tsconfig.json
+++ b/ui-library/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["./**/*.ts", "./**/*.vue"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/ui-library/vite.config.ts
+++ b/ui-library/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'index.ts'),
+      name: 'UiLibrary',
+      fileName: format => `ui-library.${format}.js`,
+      formats: ['es', 'umd'],
+    },
+    rollupOptions: {
+      external: ['vue', 'tailwindcss'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- build Vue 3 UI component library `ui-library`
- add Tailwind CSS theme and styles
- implement BaseButton, BaseInput, BaseModal and BaseTable components
- configure Vite, TypeScript and PostCSS
- document usage

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862762cac8832194fd1ddb679ed238