### PR TITLE
Initialize ui-library scaffold

### DIFF
--- a/ui-library/.storybook/main.ts
+++ b/ui-library/.storybook/main.ts
@@ -1,0 +1,24 @@
+import { StorybookConfig } from '@storybook/vue3-vite';
+import { mergeConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+const config: StorybookConfig = {
+  stories: ['../components/**/*.stories.@(ts|js)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {}
+  },
+  viteFinal: async (config) => {
+    return mergeConfig(config, {
+      plugins: [vue()],
+      resolve: {
+        alias: {
+          '@': path.resolve(__dirname, '../'),
+        },
+      },
+    });
+  },
+};
+export default config;

--- a/ui-library/.storybook/preview.ts
+++ b/ui-library/.storybook/preview.ts
@@ -1,0 +1,1 @@
+import '../theme/index.css';

--- a/ui-library/components/BaseButton.module.css
+++ b/ui-library/components/BaseButton.module.css
@@ -1,0 +1,8 @@
+.button {
+  padding: var(--spacing-md);
+  border-radius: var(--radius-md);
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+  border: none;
+  cursor: pointer;
+}

--- a/ui-library/components/BaseButton.stories.ts
+++ b/ui-library/components/BaseButton.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import BaseButton from './BaseButton.vue';
+
+const meta: Meta<typeof BaseButton> = {
+  title: 'Base/BaseButton',
+  component: BaseButton,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BaseButton>;
+
+export const Primary: Story = {
+  render: () => ({
+    components: { BaseButton },
+    template: '<BaseButton>Click me</BaseButton>',
+  }),
+};

--- a/ui-library/components/BaseButton.vue
+++ b/ui-library/components/BaseButton.vue
@@ -1,0 +1,10 @@
+<template>
+  <button :class="$style.button" type="button">
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style module src="./BaseButton.module.css"></style>

--- a/ui-library/demo/index.html
+++ b/ui-library/demo/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UI Library Demo</title>
+</head>
+<body data-theme="light">
+  <div id="app"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/ui-library/demo/src/App.vue
+++ b/ui-library/demo/src/App.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <BaseButton @click="toggle">Toggle Theme</BaseButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const current = ref<'light' | 'dark'>('light');
+
+function toggle() {
+  current.value = current.value === 'light' ? 'dark' : 'light';
+  document.body.setAttribute('data-theme', current.value);
+}
+</script>

--- a/ui-library/demo/src/main.ts
+++ b/ui-library/demo/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import '../theme/index.css';
+import { BaseButton } from '../index';
+
+createApp(App).component('BaseButton', BaseButton).mount('#app');

--- a/ui-library/demo/vite.config.ts
+++ b/ui-library/demo/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../'),
+    },
+  },
+});

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,0 +1,1 @@
+export { default as BaseButton } from './components/BaseButton.vue';

--- a/ui-library/package.json
+++ b/ui-library/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ui-library",
+  "version": "0.1.0",
+  "main": "dist/ui-library.umd.js",
+  "module": "dist/ui-library.es.js",
+  "types": "types/index.d.ts",
+  "scripts": {
+    "dev": "vite --config vite.config.ts",
+    "build": "vite build",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "preview": "vite preview",
+    "demo": "vite --config demo/vite.config.ts"
+  },
+  "dependencies": {
+    "vue": "^3.0.0"
+  },
+  "devDependencies": {
+    "@storybook/vue3": "^7.0.0",
+    "@vitejs/plugin-vue": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/ui-library/theme/base.css
+++ b/ui-library/theme/base.css
@@ -1,0 +1,6 @@
+:root {
+  --color-primary: #42b883;
+  --color-on-primary: #ffffff;
+  --spacing-md: 0.5rem 1rem;
+  --radius-md: 4px;
+}

--- a/ui-library/theme/index.css
+++ b/ui-library/theme/index.css
@@ -1,0 +1,2 @@
+@import './base.css';
+@import './themes/light.css';

--- a/ui-library/theme/themes/dark.css
+++ b/ui-library/theme/themes/dark.css
@@ -1,0 +1,6 @@
+[data-theme="dark"] {
+  --color-primary: #35495e;
+  --color-on-primary: #ffffff;
+  background-color: #121212;
+  color: #ffffff;
+}

--- a/ui-library/theme/themes/light.css
+++ b/ui-library/theme/themes/light.css
@@ -1,0 +1,6 @@
+[data-theme="light"] {
+  --color-primary: #42b883;
+  --color-on-primary: #ffffff;
+  background-color: #ffffff;
+  color: #000000;
+}

--- a/ui-library/tsconfig.json
+++ b/ui-library/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "lib": ["dom", "esnext"],
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "ui-library": ["./index.ts"],
+      "ui-library/*": ["./*"],
+    },
+    "declaration": true,
+    "declarationDir": "types"
+  },
+  "include": ["components/**/*", "index.ts", "types/index.d.ts"],
+  "exclude": ["node_modules", "dist", "demo"]
+}

--- a/ui-library/types/index.d.ts
+++ b/ui-library/types/index.d.ts
@@ -1,0 +1,1 @@
+export { default as BaseButton } from '../components/BaseButton.vue';

--- a/ui-library/vite.config.ts
+++ b/ui-library/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'index.ts'),
+      name: 'UiLibrary',
+      fileName: (format) => `ui-library.${format}.js`,
+    },
+    rollupOptions: {
+      external: ['vue'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- initialize Vue 3 UI kit project scaffold
- add BaseButton component with css module
- setup theme system with light and dark themes
- configure Storybook and Vite
- add demo app for local testing
- provide TypeScript declarations for IntelliSense

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68871f1a79c08321bc6dc229499f5a48