### PR TITLE
feat: add BaseSwitch component

### DIFF
--- a/ui-library/components/BaseSwitch.module.css
+++ b/ui-library/components/BaseSwitch.module.css
@@ -1,0 +1,137 @@
+:root {
+  --switch-width-sm: 2rem;
+  --switch-height-sm: 1rem;
+  --switch-thumb-size-sm: 0.875rem;
+
+  --switch-width-md: 2.5rem;
+  --switch-height-md: 1.25rem;
+  --switch-thumb-size-md: 1.125rem;
+
+  --switch-width-lg: 3rem;
+  --switch-height-lg: 1.5rem;
+  --switch-thumb-size-lg: 1.375rem;
+}
+
+.wrapper {
+  --switch-width: var(--switch-width-md);
+  --switch-height: var(--switch-height-md);
+  --switch-thumb-size: var(--switch-thumb-size-md);
+  --switch-padding: var(--space-xs);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  cursor: pointer;
+  user-select: none;
+}
+
+.right {
+  flex-direction: row;
+}
+
+.left {
+  flex-direction: row-reverse;
+}
+
+.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.sm {
+  --switch-width: var(--switch-width-sm);
+  --switch-height: var(--switch-height-sm);
+  --switch-thumb-size: var(--switch-thumb-size-sm);
+}
+
+.md {
+  --switch-width: var(--switch-width-md);
+  --switch-height: var(--switch-height-md);
+  --switch-thumb-size: var(--switch-thumb-size-md);
+}
+
+.lg {
+  --switch-width: var(--switch-width-lg);
+  --switch-height: var(--switch-height-lg);
+  --switch-thumb-size: var(--switch-thumb-size-lg);
+}
+
+.switch {
+  position: relative;
+  width: var(--switch-width);
+  height: var(--switch-height);
+  display: inline-block;
+}
+
+.input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  cursor: pointer;
+}
+
+.input:disabled {
+  cursor: not-allowed;
+}
+
+.track {
+  position: absolute;
+  inset: 0;
+  background-color: var(--color-disabled-bg);
+  border-radius: var(--switch-height);
+  transition: background-color var(--transition-base);
+  display: flex;
+  align-items: center;
+  padding: var(--switch-padding);
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.thumb {
+  width: var(--switch-thumb-size);
+  height: var(--switch-thumb-size);
+  background-color: var(--color-background);
+  border-radius: var(--radius-full);
+  transition: transform var(--transition-base);
+}
+
+.input:checked + .track {
+  background-color: var(--color-primary);
+}
+
+.input:checked + .track .thumb {
+  transform: translateX(calc(var(--switch-width) - var(--switch-thumb-size) - var(--switch-padding) * 2));
+}
+
+.input:focus-visible + .track {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.input:disabled + .track {
+  background-color: var(--color-disabled-bg);
+}
+
+.input:disabled + .track .thumb {
+  background-color: var(--color-disabled-text);
+}
+
+.text {
+  flex: 1;
+  text-align: center;
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  transition: color var(--transition-base);
+}
+
+.input:checked + .track .text {
+  color: var(--color-on-primary);
+}
+
+.label {
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+}

--- a/ui-library/components/BaseSwitch.stories.ts
+++ b/ui-library/components/BaseSwitch.stories.ts
@@ -1,0 +1,68 @@
+import BaseSwitch from './BaseSwitch.vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+
+export default {
+  title: 'Components/BaseSwitch',
+  component: BaseSwitch,
+  argTypes: {
+    modelValue: { control: 'boolean' },
+    label: { control: 'text' },
+    disabled: { control: 'boolean' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    onText: { control: 'text' },
+    offText: { control: 'text' },
+    name: { control: 'text' },
+    id: { control: 'text' },
+    labelPosition: { control: { type: 'select' }, options: ['left', 'right'] },
+  },
+} satisfies Meta<typeof BaseSwitch>
+
+const Template: StoryFn<typeof BaseSwitch> = (args) => ({
+  components: { BaseSwitch },
+  setup: () => ({ args }),
+  template: '<BaseSwitch v-model="args.modelValue" v-bind="args" />',
+})
+
+export const Default = Template.bind({})
+Default.args = {
+  modelValue: false,
+}
+
+export const Checked = Template.bind({})
+Checked.args = {
+  modelValue: true,
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  disabled: true,
+}
+
+export const WithLabel = Template.bind({})
+WithLabel.args = {
+  label: 'Toggle me',
+}
+
+export const LabelLeft = Template.bind({})
+LabelLeft.args = {
+  label: 'Label on left',
+  labelPosition: 'left',
+}
+
+export const Sizes = () => ({
+  components: { BaseSwitch },
+  template: `
+    <div style="display: flex; gap: 1rem; align-items: center;">
+      <BaseSwitch size="sm" />
+      <BaseSwitch size="md" />
+      <BaseSwitch size="lg" />
+    </div>
+  `,
+})
+
+export const WithText = Template.bind({})
+WithText.args = {
+  onText: 'On',
+  offText: 'Off',
+  modelValue: true,
+}

--- a/ui-library/components/BaseSwitch.vue
+++ b/ui-library/components/BaseSwitch.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useAttrs } from 'vue'
+import styles from './BaseSwitch.module.css'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    label?: string
+    disabled?: boolean
+    size?: 'sm' | 'md' | 'lg'
+    onText?: string
+    offText?: string
+    name?: string
+    id?: string
+    labelPosition?: 'left' | 'right'
+  }>(),
+  {
+    modelValue: false,
+    disabled: false,
+    size: 'md',
+    labelPosition: 'right'
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const attrs = useAttrs()
+
+function toggle() {
+  if (props.disabled) return
+  emit('update:modelValue', !props.modelValue)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    toggle()
+  }
+}
+</script>
+
+<template>
+  <label
+    :class="[styles.wrapper, styles[size], styles[labelPosition], disabled && styles.disabled]"
+    v-bind="attrs"
+  >
+    <span v-if="label && labelPosition === 'left'" :class="styles.label">{{ label }}</span>
+
+    <span :class="styles.switch">
+      <input
+        :id="id"
+        :name="name"
+        type="checkbox"
+        :checked="modelValue"
+        :disabled="disabled"
+        :class="styles.input"
+        role="switch"
+        :aria-checked="modelValue"
+        @change="toggle"
+        @keydown="onKeydown"
+      />
+      <span :class="styles.track">
+        <span :class="styles.thumb"></span>
+        <span v-if="onText || offText" :class="styles.text">
+          {{ modelValue ? onText : offText }}
+        </span>
+      </span>
+    </span>
+
+    <span v-if="label && labelPosition === 'right'" :class="styles.label">{{ label }}</span>
+  </label>
+</template>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,1 +1,2 @@
 export { default as BaseButton } from './components/BaseButton.vue';
+export { default as BaseSwitch } from './components/BaseSwitch.vue';


### PR DESCRIPTION
## Summary
- add accessible BaseSwitch component with theming and size options
- style switch via CSS variables for full customization
- document BaseSwitch in Storybook with key states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: Permission denied)*


------
https://chatgpt.com/codex/tasks/task_e_689212548ea88321b3ed1aa378abca19