### PR TITLE
feat: add BaseModal component

### DIFF
--- a/ui-library/components/BaseModal.module.css
+++ b/ui-library/components/BaseModal.module.css
@@ -1,0 +1,95 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--modal-overlay-bg);
+  z-index: var(--z-index-modal);
+}
+
+.wrapper {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-index-modal);
+}
+
+.wrapperFullscreen {
+  align-items: stretch;
+  justify-content: stretch;
+}
+
+.box {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  width: var(--modal-width);
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: var(--border-width) var(--border-style) var(--color-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.fullscreen {
+  width: var(--modal-fullscreen-width);
+  height: var(--modal-fullscreen-height);
+  border-radius: var(--modal-fullscreen-radius);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: var(--space-md);
+  margin-bottom: var(--space-lg);
+  border-bottom: var(--border-width) var(--border-style) var(--color-border);
+}
+
+.title {
+  margin: 0;
+}
+
+.close {
+  width: var(--space-2xl);
+  height: var(--space-2xl);
+  background-color: var(--modal-close-bg, transparent);
+  border: var(--modal-close-border, none);
+  color: var(--color-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  margin-bottom: var(--space-lg);
+}
+
+.footer {
+  padding-top: var(--space-md);
+  border-top: var(--border-width) var(--border-style) var(--color-border);
+}
+
+:global(.modal-enter-active),
+:global(.modal-leave-active) {
+  transition: opacity var(--transition-base), transform var(--transition-base);
+}
+
+:global(.modal-enter-from),
+:global(.modal-leave-to) {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+:global(.overlay-enter-active),
+:global(.overlay-leave-active) {
+  transition: opacity var(--transition-base);
+}
+
+:global(.overlay-enter-from),
+:global(.overlay-leave-to) {
+  opacity: 0;
+}

--- a/ui-library/components/BaseModal.stories.ts
+++ b/ui-library/components/BaseModal.stories.ts
@@ -1,0 +1,84 @@
+import BaseModal from './BaseModal.vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+export default {
+  title: 'Components/BaseModal',
+  component: BaseModal,
+  argTypes: {
+    modelValue: { control: 'boolean' },
+    title: { control: 'text' },
+    width: { control: 'text' },
+    fullscreen: { control: 'boolean' },
+    closable: { control: 'boolean' },
+    persistent: { control: 'boolean' },
+    hideOverlay: { control: 'boolean' }
+  }
+} satisfies Meta<typeof BaseModal>
+
+const Template: StoryFn<typeof BaseModal> = (args) => ({
+  components: { BaseModal },
+  setup() {
+    const open = ref(true)
+    return { args, open }
+  },
+  template: `
+    <BaseModal v-model="open" v-bind="args">
+      <p>This is a modal.</p>
+    </BaseModal>
+  `
+})
+
+export const Default = Template.bind({})
+Default.args = {
+  modelValue: true,
+  title: 'Default Modal'
+}
+
+export const LongContent = () => ({
+  components: { BaseModal },
+  setup() {
+    const open = ref(true)
+    return { open }
+  },
+  template: `
+    <BaseModal v-model="open" title="Long Content">
+      <p v-for="i in 20" :key="i">Line {{ i }}</p>
+    </BaseModal>
+  `
+})
+
+export const Fullscreen = Template.bind({})
+Fullscreen.args = {
+  modelValue: true,
+  fullscreen: true,
+  title: 'Fullscreen'
+}
+
+export const Persistent = Template.bind({})
+Persistent.args = {
+  modelValue: true,
+  persistent: true,
+  title: 'Persistent Modal'
+}
+
+export const WithoutOverlay = Template.bind({})
+WithoutOverlay.args = {
+  modelValue: true,
+  hideOverlay: true,
+  title: 'No Overlay'
+}
+
+export const CustomWidth = Template.bind({})
+CustomWidth.args = {
+  modelValue: true,
+  width: '400px',
+  title: 'Custom Width'
+}
+
+export const TitleNoClose = Template.bind({})
+TitleNoClose.args = {
+  modelValue: true,
+  title: 'No Close Button',
+  closable: false
+}

--- a/ui-library/components/BaseModal.vue
+++ b/ui-library/components/BaseModal.vue
@@ -1,0 +1,155 @@
+<template>
+  <Teleport to="body">
+    <transition name="overlay">
+      <div v-if="modelValue && !hideOverlay" :class="styles.overlay"></div>
+    </transition>
+    <div
+      v-if="modelValue"
+      :class="[styles.wrapper, fullscreen && styles.wrapperFullscreen]"
+      @click.self="onOverlayClick"
+    >
+      <transition name="modal">
+        <div
+          v-if="modelValue"
+          ref="modalRef"
+          :class="[styles.box, fullscreen && styles.fullscreen]"
+          role="dialog"
+          aria-modal="true"
+          :aria-labelledby="computedLabelledby"
+          :aria-describedby="ariaDescribedby"
+          :style="modalStyles"
+          tabindex="-1"
+          @keydown.stop
+        >
+          <header v-if="title || closable" :class="styles.header">
+            <h2 v-if="title" :id="computedLabelledby" :class="styles.title">{{ title }}</h2>
+            <button
+              v-if="closable"
+              type="button"
+              :class="styles.close"
+              aria-label="Close"
+              @click="close"
+            >
+              ×
+            </button>
+          </header>
+          <div :class="styles.body">
+            <slot />
+          </div>
+          <footer v-if="$slots.footer" :class="styles.footer">
+            <slot name="footer" />
+          </footer>
+        </div>
+      </transition>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, nextTick, computed } from 'vue'
+import styles from './BaseModal.module.css'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    title?: string
+    width?: string
+    fullscreen?: boolean
+    closable?: boolean
+    persistent?: boolean
+    hideOverlay?: boolean
+    ariaLabelledby?: string
+    ariaDescribedby?: string
+  }>(),
+  {
+    width: '600px',
+    fullscreen: false,
+    closable: true,
+    persistent: false,
+    hideOverlay: false
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'close'): void
+}>()
+
+const modalRef = ref<HTMLElement | null>(null)
+const previouslyFocused = ref<HTMLElement | null>(null)
+const id = `modal-${Math.random().toString(36).slice(2, 9)}`
+
+const computedLabelledby = computed(() => props.ariaLabelledby ?? (props.title ? id : undefined))
+
+const modalStyles = computed(() => ({
+  '--modal-width': props.width,
+  '--modal-fullscreen-width': '100vw',
+  '--modal-fullscreen-height': '100vh',
+  '--modal-fullscreen-radius': '0'
+}))
+
+const focusableSelector =
+  'a[href],area[href],input:not([disabled]):not([type="hidden"]),select:not([disabled]),textarea:not([disabled]),button:not([disabled]),iframe,object,embed,[tabindex]:not([tabindex="-1"]),[contenteditable]'
+
+function trap(e: KeyboardEvent) {
+  if (e.key === 'Escape' && !props.persistent) {
+    close()
+    return
+  }
+  if (e.key !== 'Tab') return
+  const focusables = modalRef.value?.querySelectorAll<HTMLElement>(focusableSelector)
+  if (!focusables || focusables.length === 0) {
+    e.preventDefault()
+    return
+  }
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  const active = document.activeElement as HTMLElement
+  if (e.shiftKey) {
+    if (active === first || !modalRef.value?.contains(active)) {
+      e.preventDefault()
+      last.focus()
+    }
+  } else if (active === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+function open() {
+  previouslyFocused.value = document.activeElement as HTMLElement | null
+  document.addEventListener('keydown', trap)
+  nextTick(() => {
+    const focusables = modalRef.value?.querySelectorAll<HTMLElement>(focusableSelector)
+    ;(focusables && focusables[0] ? focusables[0] : modalRef.value)?.focus()
+  })
+}
+
+function cleanup() {
+  document.removeEventListener('keydown', trap)
+  previouslyFocused.value?.focus()
+}
+
+function close() {
+  emit('update:modelValue', false)
+  emit('close')
+}
+
+function onOverlayClick() {
+  if (props.persistent || !props.closable) return
+  close()
+}
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (val) open()
+    else cleanup()
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => cleanup())
+</script>
+
+<style module src="./BaseModal.module.css"></style>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,2 +1,3 @@
 export { default as BaseButton } from './components/BaseButton.vue';
 export { default as BaseSwitch } from './components/BaseSwitch.vue';
+export { default as BaseModal } from './components/BaseModal.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseModal component with accessibility, focus trapping and theming support
- style modal via CSS Modules and CSS variables
- document modal usage with comprehensive Storybook stories

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689217c800448321a7ef4dfd7aa194ba