### PR TITLE
feat: add BaseTextarea component

### DIFF
--- a/ui-library/components/BaseTextarea.module.css
+++ b/ui-library/components/BaseTextarea.module.css
@@ -1,0 +1,71 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.textarea {
+  width: 100%;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: var(--border-width) var(--border-style) var(--color-border);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  transition: var(--transition-base);
+  resize: vertical;
+}
+
+.textarea[aria-invalid='true'] {
+  border-color: var(--color-error);
+}
+
+.focused {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 var(--border-width) var(--color-primary);
+}
+
+.disabled {
+  background-color: var(--color-disabled-bg);
+  color: var(--color-disabled-text);
+  cursor: not-allowed;
+}
+
+.hint {
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+}
+
+.error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.counter {
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+  text-align: right;
+}
+
+.resizeNone {
+  resize: none;
+}
+
+.resizeBoth {
+  resize: both;
+}
+
+.resizeHorizontal {
+  resize: horizontal;
+}
+
+.resizeVertical {
+  resize: vertical;
+}

--- a/ui-library/components/BaseTextarea.stories.ts
+++ b/ui-library/components/BaseTextarea.stories.ts
@@ -1,0 +1,99 @@
+import BaseTextarea from './BaseTextarea.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof BaseTextarea> = {
+  title: 'Form/BaseTextarea',
+  component: BaseTextarea,
+  argTypes: {
+    modelValue: { control: 'text' },
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    rows: { control: 'number' },
+    maxLength: { control: 'number' },
+    resize: { control: 'select', options: ['none', 'both', 'horizontal', 'vertical'] },
+    autoResize: { control: 'boolean' },
+    error: { control: 'text' },
+    hint: { control: 'text' },
+    name: { control: 'text' },
+    id: { control: 'text' }
+  },
+  args: {
+    modelValue: '',
+    rows: 3,
+    resize: 'vertical'
+  }
+}
+export default meta
+
+type Story = StoryObj<typeof BaseTextarea>
+
+export const Default: Story = {}
+
+export const WithLabelAndPlaceholder: Story = {
+  args: {
+    label: 'Message',
+    placeholder: 'Type your message...'
+  }
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    label: 'Disabled',
+    modelValue: 'Cannot edit'
+  }
+}
+
+export const Readonly: Story = {
+  args: {
+    readonly: true,
+    label: 'Readonly',
+    modelValue: 'Read only text'
+  }
+}
+
+export const WithHintAndError: Story = {
+  args: {
+    label: 'Feedback',
+    hint: 'Let us know what you think',
+    error: 'This field is required'
+  }
+}
+
+export const WithMaxLength: Story = {
+  args: {
+    label: 'Limited',
+    maxLength: 100,
+    hint: 'Max 100 characters'
+  }
+}
+
+export const AutoResize: Story = {
+  args: {
+    label: 'Auto resize',
+    autoResize: true,
+    modelValue: 'Start typing...'
+  }
+}
+
+export const CustomRows: Story = {
+  args: {
+    label: 'Five rows',
+    rows: 5
+  }
+}
+
+export const Themed: Story = {
+  render: (args) => ({
+    components: { BaseTextarea },
+    setup: () => ({ args }),
+    template: `
+      <div style="display: flex; gap: 1rem;">
+        <div data-theme="light"><BaseTextarea v-bind="args" label="Light" placeholder="Light theme" /></div>
+        <div data-theme="dark"><BaseTextarea v-bind="args" label="Dark" placeholder="Dark theme" /></div>
+      </div>
+    `
+  })
+}

--- a/ui-library/components/BaseTextarea.vue
+++ b/ui-library/components/BaseTextarea.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import styles from './BaseTextarea.module.css'
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  label?: string
+  placeholder?: string
+  disabled?: boolean
+  readonly?: boolean
+  rows?: number
+  maxLength?: number
+  resize?: 'none' | 'both' | 'horizontal' | 'vertical'
+  autoResize?: boolean
+  error?: string | boolean
+  hint?: string
+  name?: string
+  id?: string
+}>(), {
+  rows: 3,
+  resize: 'vertical',
+  disabled: false,
+  readonly: false,
+  autoResize: false
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+  (e: 'input', event: Event): void
+  (e: 'focus', event: FocusEvent): void
+  (e: 'blur', event: FocusEvent): void
+}>()
+
+const textareaRef = ref<HTMLTextAreaElement>()
+const isFocused = ref(false)
+
+const textareaId = computed(() => props.id || `textarea-${Math.random().toString(36).slice(2)}`)
+const hintId = computed(() => props.hint ? `${textareaId.value}-hint` : undefined)
+const errorId = computed(() => typeof props.error === 'string' ? `${textareaId.value}-error` : undefined)
+const describedBy = computed(() => [hintId.value, errorId.value].filter(Boolean).join(' ') || undefined)
+
+const resizeClass = computed(() => {
+  switch (props.resize) {
+    case 'none':
+      return styles.resizeNone
+    case 'both':
+      return styles.resizeBoth
+    case 'horizontal':
+      return styles.resizeHorizontal
+    default:
+      return styles.resizeVertical
+  }
+})
+
+const classes = computed(() => [
+  styles.textarea,
+  resizeClass.value,
+  props.disabled && styles.disabled,
+  isFocused.value && styles.focused
+])
+
+const adjustHeight = () => {
+  const el = textareaRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  el.style.height = `${el.scrollHeight}px`
+}
+
+const onInput = (e: Event) => {
+  const value = (e.target as HTMLTextAreaElement).value
+  emit('update:modelValue', value)
+  emit('input', e)
+  if (props.autoResize) adjustHeight()
+}
+
+const onFocus = (e: FocusEvent) => {
+  isFocused.value = true
+  emit('focus', e)
+}
+
+const onBlur = (e: FocusEvent) => {
+  isFocused.value = false
+  emit('blur', e)
+}
+
+watch(() => props.modelValue, () => {
+  if (props.autoResize) nextTick(adjustHeight)
+})
+
+onMounted(() => {
+  if (props.autoResize) adjustHeight()
+})
+</script>
+
+<template>
+  <div :class="styles.wrapper">
+    <label v-if="label" :for="textareaId" :class="styles.label">{{ label }}</label>
+    <textarea
+      ref="textareaRef"
+      :id="textareaId"
+      :name="name"
+      :class="classes"
+      :rows="rows"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      :readonly="readonly"
+      :maxlength="maxLength"
+      :aria-invalid="!!error"
+      :aria-describedby="describedBy"
+      :value="modelValue"
+      @input="onInput"
+      @focus="onFocus"
+      @blur="onBlur"
+    />
+    <div v-if="hint && !error" :id="hintId" :class="styles.hint">{{ hint }}</div>
+    <div v-if="typeof error === 'string'" :id="errorId" :class="styles.error">{{ error }}</div>
+    <div v-if="maxLength" :class="styles.counter">{{ modelValue.length }} / {{ maxLength }}</div>
+  </div>
+</template>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,3 +1,4 @@
 export { default as BaseButton } from './components/BaseButton.vue';
 export { default as BaseSwitch } from './components/BaseSwitch.vue';
 export { default as BaseModal } from './components/BaseModal.vue';
+export { default as BaseTextarea } from './components/BaseTextarea.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseTextarea component with auto-resize and character counter
- style textarea with design tokens and state classes
- document BaseTextarea usage in Storybook and export from library index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923d66ec308321b8d2eb713f261b48