### PR TITLE
feat: add BaseSelect component

### DIFF
--- a/ui-library/components/BaseSelect.module.css
+++ b/ui-library/components/BaseSelect.module.css
@@ -1,0 +1,159 @@
+.wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  font-family: var(--font-family-base);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.control {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-width) var(--border-style) var(--color-border);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: var(--transition-base);
+}
+
+.control:hover,
+.open {
+  border-color: var(--color-primary);
+}
+
+.value {
+  flex: 1;
+  color: var(--color-text);
+  font-size: var(--font-size-md);
+}
+
+.placeholder {
+  flex: 1;
+  color: var(--color-muted);
+  font-size: var(--font-size-md);
+}
+
+.icon {
+  margin-left: auto;
+  color: var(--color-muted);
+  font-size: var(--font-size-md);
+}
+
+.clear {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  font-size: var(--font-size-md);
+}
+
+.spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: var(--space-xs);
+  border: var(--border-width) var(--border-style) var(--color-border);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: var(--z-index-dropdown, 10);
+}
+
+.search {
+  padding: var(--space-xs);
+  border-bottom: var(--border-width) var(--border-style) var(--color-border);
+}
+
+.searchInput {
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--border-width) var(--border-style) var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+}
+
+.searchInput:focus {
+  border-color: var(--color-primary);
+  outline: none;
+}
+
+.option {
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+  transition: var(--transition-base);
+}
+
+.option:hover,
+.active {
+  background: var(--color-secondary);
+  color: var(--color-on-secondary);
+}
+
+.selected {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.noOptions {
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.error {
+  border-color: var(--color-error);
+}
+
+.disabled {
+  background: var(--color-disabled-bg);
+  color: var(--color-disabled-text);
+  cursor: not-allowed;
+}
+
+.readonly {
+  cursor: default;
+}
+
+.loading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.errorMessage {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.hint {
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+}

--- a/ui-library/components/BaseSelect.stories.ts
+++ b/ui-library/components/BaseSelect.stories.ts
@@ -1,0 +1,122 @@
+import { ref } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+import BaseSelect from './BaseSelect.vue'
+
+const baseOptions = [
+  { label: 'Option One', value: 'one' },
+  { label: 'Option Two', value: 'two' },
+  { label: 'Option Three', value: 'three' },
+]
+
+const meta: Meta<typeof BaseSelect> = {
+  title: 'Form/BaseSelect',
+  component: BaseSelect,
+  args: {
+    modelValue: null,
+    options: baseOptions,
+    placeholder: 'Select option',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof BaseSelect>
+
+const Template = (args: any) => ({
+  components: { BaseSelect },
+  setup() {
+    const value = ref(args.modelValue)
+    return { args, value }
+  },
+  template: `<BaseSelect v-model="value" v-bind="args" />`,
+})
+
+export const Default: Story = { render: Template }
+
+export const WithLabel: Story = {
+  render: Template,
+  args: {
+    label: 'Choose option',
+    placeholder: 'Please select',
+  },
+}
+
+export const Disabled: Story = {
+  render: Template,
+  args: {
+    disabled: true,
+    label: 'Disabled',
+    placeholder: 'Disabled',
+  },
+}
+
+export const ErrorAndHint: Story = {
+  render: Template,
+  args: {
+    label: 'With error',
+    error: 'Selection required',
+    hint: 'Please choose an option',
+  },
+}
+
+export const Searchable: Story = {
+  render: Template,
+  args: {
+    label: 'Searchable',
+    searchable: true,
+  },
+}
+
+export const Clearable: Story = {
+  render: Template,
+  args: {
+    label: 'Clearable',
+    clearable: true,
+    modelValue: 'two',
+  },
+}
+
+export const Loading: Story = {
+  render: Template,
+  args: {
+    label: 'Loading',
+    loading: true,
+    placeholder: 'Loading...',
+  },
+}
+
+export const LargeList: Story = {
+  render: Template,
+  args: {
+    label: 'Many options',
+    options: Array.from({ length: 50 }, (_, i) => ({
+      label: `Option ${i + 1}`,
+      value: i + 1,
+    })),
+  },
+}
+
+export const KeyboardNavigation: Story = {
+  render: Template,
+  args: {
+    label: 'Use arrow keys',
+    searchable: true,
+  },
+}
+
+export const DarkTheme: Story = {
+  render: (args) => ({
+    components: { BaseSelect },
+    setup() {
+      const value = ref(null)
+      return { args, value }
+    },
+    template: `
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <BaseSelect v-model="value" v-bind="args" label="Light theme" />
+        <div data-theme="dark" style="padding:1rem;">
+          <BaseSelect v-model="value" v-bind="args" label="Dark theme" />
+        </div>
+      </div>
+    `,
+  }),
+}

--- a/ui-library/components/BaseSelect.vue
+++ b/ui-library/components/BaseSelect.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch, withDefaults, defineProps } from 'vue'
+import styles from './BaseSelect.module.css'
+
+interface Option {
+  label: string
+  value: string | number
+}
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string | number | null
+    options: Option[]
+    label?: string
+    placeholder?: string
+    disabled?: boolean
+    readonly?: boolean
+    error?: string | boolean
+    hint?: string
+    name?: string
+    id?: string
+    searchable?: boolean
+    clearable?: boolean
+    loading?: boolean
+    dropdownIcon?: boolean
+  }>(),
+  {
+    placeholder: '',
+    disabled: false,
+    readonly: false,
+    error: false,
+    hint: '',
+    name: '',
+    id: undefined,
+    searchable: false,
+    clearable: false,
+    loading: false,
+    dropdownIcon: true,
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | number | null): void
+  (e: 'focus', evt: FocusEvent): void
+  (e: 'blur', evt: FocusEvent): void
+  (e: 'change', value: string | number | null): void
+}>()
+
+const isOpen = ref(false)
+const search = ref('')
+const activeIndex = ref(-1)
+const rootRef = ref<HTMLElement | null>(null)
+const searchRef = ref<HTMLInputElement | null>(null)
+
+const uid = Math.random().toString(36).slice(2)
+const selectId = computed(() => props.id || `base-select-${uid}`)
+const labelId = computed(() => `${selectId.value}-label`)
+const listId = computed(() => `${selectId.value}-list`)
+const activeId = computed(() =>
+  activeIndex.value >= 0 ? `${selectId.value}-option-${activeIndex.value}` : undefined
+)
+
+const filteredOptions = computed(() => {
+  if (!props.searchable || !search.value) return props.options
+  return props.options.filter(o =>
+    o.label.toLowerCase().includes(search.value.toLowerCase())
+  )
+})
+
+const selectedOption = computed(() =>
+  props.options.find(o => o.value === props.modelValue) || null
+)
+
+const hasValue = computed(() =>
+  props.modelValue !== null && props.modelValue !== undefined && props.modelValue !== ''
+)
+
+function openDropdown() {
+  if (props.disabled || props.readonly || props.loading) return
+  isOpen.value = true
+  if (props.searchable) {
+    requestAnimationFrame(() => searchRef.value?.focus())
+  }
+}
+
+function closeDropdown() {
+  isOpen.value = false
+  activeIndex.value = -1
+  search.value = ''
+}
+
+function toggleDropdown() {
+  isOpen.value ? closeDropdown() : openDropdown()
+}
+
+function selectOption(opt: Option) {
+  if (props.disabled || props.readonly || props.loading) return
+  emit('update:modelValue', opt.value)
+  emit('change', opt.value)
+  closeDropdown()
+}
+
+function clearSelection(e: MouseEvent) {
+  e.stopPropagation()
+  emit('update:modelValue', null)
+  emit('change', null)
+}
+
+function onDocumentClick(e: MouseEvent) {
+  if (!rootRef.value?.contains(e.target as Node)) {
+    closeDropdown()
+  }
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (props.disabled || props.readonly || props.loading) return
+  const max = filteredOptions.value.length - 1
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault()
+      if (!isOpen.value) openDropdown()
+      activeIndex.value = activeIndex.value < max ? activeIndex.value + 1 : 0
+      break
+    case 'ArrowUp':
+      e.preventDefault()
+      if (!isOpen.value) openDropdown()
+      activeIndex.value = activeIndex.value > 0 ? activeIndex.value - 1 : max
+      break
+    case 'Enter':
+      e.preventDefault()
+      if (!isOpen.value) {
+        openDropdown()
+      } else if (activeIndex.value >= 0) {
+        const opt = filteredOptions.value[activeIndex.value]
+        if (opt) selectOption(opt)
+      }
+      break
+    case 'Escape':
+      if (isOpen.value) {
+        e.preventDefault()
+        closeDropdown()
+      }
+      break
+  }
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick))
+onBeforeUnmount(() => document.removeEventListener('click', onDocumentClick))
+
+watch(filteredOptions, () => {
+  if (activeIndex.value >= filteredOptions.value.length) {
+    activeIndex.value = filteredOptions.value.length - 1
+  }
+})
+</script>
+
+<template>
+  <div :class="styles.wrapper" ref="rootRef">
+    <label
+      v-if="label"
+      :for="selectId"
+      :id="labelId"
+      :class="styles.label"
+    >{{ label }}</label>
+
+    <div
+      :id="selectId"
+      ref="triggerRef"
+      role="combobox"
+      :aria-haspopup="'listbox'"
+      :aria-expanded="isOpen"
+      :aria-controls="listId"
+      :aria-activedescendant="activeId"
+      :aria-disabled="disabled || undefined"
+      :aria-readonly="readonly || undefined"
+      :aria-labelledby="label ? labelId : undefined"
+      tabindex="0"
+      @click="toggleDropdown"
+      @keydown="handleKeydown"
+      @focus="(e) => emit('focus', e)"
+      @blur="(e) => emit('blur', e)"
+      :class="[
+        styles.control,
+        disabled && styles.disabled,
+        readonly && styles.readonly,
+        error && styles.error,
+        isOpen && styles.open,
+        loading && styles.loading,
+      ]"
+    >
+      <span v-if="selectedOption" :class="styles.value">{{ selectedOption.label }}</span>
+      <span v-else :class="styles.placeholder">{{ placeholder }}</span>
+      <button
+        v-if="clearable && hasValue && !disabled && !readonly"
+        type="button"
+        :class="styles.clear"
+        @click="clearSelection"
+        aria-label="Clear selection"
+      >×</button>
+      <span v-if="dropdownIcon" :class="styles.icon">▼</span>
+      <span v-if="loading" :class="styles.spinner" aria-hidden="true"></span>
+      <input
+        v-if="name"
+        type="hidden"
+        :name="name"
+        :value="selectedOption ? selectedOption.value : ''"
+      />
+    </div>
+
+    <ul
+      v-show="isOpen"
+      :id="listId"
+      role="listbox"
+      :class="styles.dropdown"
+    >
+      <li v-if="searchable" :class="styles.search">
+        <input
+          ref="searchRef"
+          v-model="search"
+          type="text"
+          :class="styles.searchInput"
+          :placeholder="placeholder"
+          @keydown.stop="handleKeydown"
+        />
+      </li>
+      <li
+        v-for="(opt, index) in filteredOptions"
+        :key="opt.value"
+        :id="`${selectId}-option-${index}`"
+        role="option"
+        :aria-selected="opt.value === modelValue"
+        @click="selectOption(opt)"
+        @mousemove="activeIndex = index"
+        :class="[
+          styles.option,
+          opt.value === modelValue && styles.selected,
+          index === activeIndex && styles.active,
+        ]"
+      >
+        {{ opt.label }}
+      </li>
+      <li v-if="!filteredOptions.length" :class="styles.noOptions">No options</li>
+    </ul>
+
+    <div v-if="typeof error === 'string'" :class="styles.errorMessage">{{ error }}</div>
+    <div v-else-if="hint" :class="styles.hint">{{ hint }}</div>
+  </div>
+</template>
+
+<style module src="./BaseSelect.module.css"></style>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,3 +1,4 @@
 export { default as BaseButton } from './components/BaseButton.vue';
 export { default as BaseSwitch } from './components/BaseSwitch.vue';
 export { default as BaseModal } from './components/BaseModal.vue';
+export { default as BaseSelect } from './components/BaseSelect.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseSelect component with search, clear and keyboard support
- style select using CSS variables and module stylesheet
- add comprehensive storybook stories and export component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923e1d7a40832183c8bdd5e8c00049