### PR TITLE
feat: add BaseTooltip component

### DIFF
--- a/ui-library/components/BaseTooltip.module.css
+++ b/ui-library/components/BaseTooltip.module.css
@@ -1,0 +1,82 @@
+.wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: absolute;
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-base);
+  max-width: calc(var(--space-2xl) * 5);
+  z-index: var(--tooltip-z-index, var(--z-index-tooltip));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  white-space: normal;
+}
+
+.isVisible {
+  opacity: 1;
+}
+
+.position-top {
+  bottom: calc(100% + var(--tooltip-offset, var(--space-sm)));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.position-bottom {
+  top: calc(100% + var(--tooltip-offset, var(--space-sm)));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.position-left {
+  right: calc(100% + var(--tooltip-offset, var(--space-sm)));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.position-right {
+  left: calc(100% + var(--tooltip-offset, var(--space-sm)));
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.arrow {
+  position: absolute;
+  width: var(--space-sm);
+  height: var(--space-sm);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  transform: rotate(45deg);
+}
+
+.position-top .arrow {
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.position-bottom .arrow {
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, 50%) rotate(45deg);
+}
+
+.position-left .arrow {
+  left: 100%;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.position-right .arrow {
+  right: 100%;
+  top: 50%;
+  transform: translate(50%, -50%) rotate(45deg);
+}

--- a/ui-library/components/BaseTooltip.stories.ts
+++ b/ui-library/components/BaseTooltip.stories.ts
@@ -1,0 +1,186 @@
+import BaseTooltip from './BaseTooltip.vue'
+import BaseButton from './BaseButton.vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+export default {
+  title: 'Components/BaseTooltip',
+  component: BaseTooltip,
+  argTypes: {
+    position: { control: { type: 'select' }, options: ['top', 'bottom', 'left', 'right'] },
+    trigger: { control: { type: 'select' }, options: ['hover', 'click', 'focus', 'manual'] },
+    animation: { control: { type: 'select' }, options: ['fade', 'scale', 'slide-up', 'slide-down', 'none'] },
+    delay: { control: 'number' },
+    persistent: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    offset: { control: 'number' },
+    closeOnClickOutside: { control: 'boolean' },
+  },
+} satisfies Meta<typeof BaseTooltip>
+
+const Template: StoryFn<typeof BaseTooltip> = (args) => ({
+  components: { BaseTooltip },
+  setup: () => ({ args }),
+  template: `
+    <BaseTooltip v-bind="args">
+      <template #activator="{ on, attrs }">
+        <span v-bind="attrs" v-on="on">Hover me</span>
+      </template>
+    </BaseTooltip>
+  `,
+})
+
+export const Default = Template.bind({})
+Default.args = {
+  text: 'Tooltip text',
+}
+
+export const ClickTrigger = Template.bind({})
+ClickTrigger.args = {
+  text: 'Click tooltip',
+  trigger: 'click',
+}
+
+export const FocusTrigger = Template.bind({})
+FocusTrigger.args = {
+  text: 'Focus tooltip',
+  trigger: 'focus',
+}
+
+export const WithBaseButtonActivator: StoryFn<typeof BaseTooltip> = (args) => ({
+  components: { BaseTooltip, BaseButton },
+  setup: () => ({ args }),
+  template: `
+    <BaseTooltip v-bind="args">
+      <template #activator="{ on, attrs }">
+        <BaseButton v-bind="attrs" v-on="on">Hover me</BaseButton>
+      </template>
+    </BaseTooltip>
+  `,
+})
+WithBaseButtonActivator.args = {
+  text: 'Using BaseButton',
+}
+
+export const CustomContent: StoryFn<typeof BaseTooltip> = (args) => ({
+  components: { BaseTooltip, BaseButton },
+  setup: () => ({ args }),
+  template: `
+    <BaseTooltip v-bind="args">
+      <template #activator="{ on, attrs }">
+        <BaseButton v-bind="attrs" v-on="on">Hover me</BaseButton>
+      </template>
+      <template #default>
+        <strong>Custom</strong> slot content
+      </template>
+    </BaseTooltip>
+  `,
+})
+CustomContent.args = {
+  text: 'Ignored',
+}
+
+export const Manual = () => ({
+  components: { BaseTooltip, BaseButton },
+  setup() {
+    const open = ref(false)
+    return { open }
+  },
+  template: `
+    <div style="display: flex; gap: 1rem; align-items: center;">
+      <BaseButton @click="open = !open">Toggle Tooltip</BaseButton>
+      <BaseTooltip :open="open" trigger="manual" text="Manual tooltip">
+        <template #activator="{ attrs }">
+          <BaseButton icon v-bind="attrs">i</BaseButton>
+        </template>
+      </BaseTooltip>
+    </div>
+  `,
+})
+
+export const Positions = () => ({
+  components: { BaseTooltip, BaseButton },
+  template: `
+    <div style="display: flex; gap: 2rem;">
+      <BaseTooltip text="Top" position="top">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Top</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Right" position="right">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Right</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Bottom" position="bottom">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Bottom</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Left" position="left">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Left</BaseButton>
+        </template>
+      </BaseTooltip>
+    </div>
+  `,
+})
+
+export const Animations = () => ({
+  components: { BaseTooltip, BaseButton },
+  template: `
+    <div style="display: flex; gap: 1rem;">
+      <BaseTooltip text="Fade" animation="fade">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Fade</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Scale" animation="scale">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Scale</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Slide Up" animation="slide-up">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Slide Up</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="Slide Down" animation="slide-down">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Slide Down</BaseButton>
+        </template>
+      </BaseTooltip>
+      <BaseTooltip text="None" animation="none">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">None</BaseButton>
+        </template>
+      </BaseTooltip>
+    </div>
+  `,
+})
+
+export const WithDelay = Template.bind({})
+WithDelay.args = {
+  text: 'Delayed tooltip',
+  delay: 500,
+}
+
+export const Persistent = Template.bind({})
+Persistent.args = {
+  text: 'Persistent tooltip',
+  persistent: true,
+  trigger: 'click',
+}
+
+export const DarkTheme = () => ({
+  components: { BaseTooltip, BaseButton },
+  template: `
+    <div data-theme="dark" style="padding: 2rem; background: var(--color-surface);">
+      <BaseTooltip text="Dark theme tooltip">
+        <template #activator="{ on, attrs }">
+          <BaseButton v-bind="attrs" v-on="on">Hover me</BaseButton>
+        </template>
+      </BaseTooltip>
+    </div>
+  `,
+})

--- a/ui-library/components/BaseTooltip.vue
+++ b/ui-library/components/BaseTooltip.vue
@@ -1,0 +1,163 @@
+<template>
+  <span ref="wrapper" :class="$style.wrapper">
+    <slot name="activator" :on="listeners" :attrs="activatorAttrs" />
+    <transition :name="transitionName">
+      <div
+        v-show="isVisible"
+        :id="tooltipId"
+        role="tooltip"
+        :class="[$style.tooltip, $style[`position-${props.position}`], { [$style.isVisible]: isVisible }]"
+        :style="tooltipStyle"
+      >
+        <slot v-if="$slots.default" />
+        <span v-else>{{ props.text }}</span>
+        <span :class="$style.arrow"></span>
+      </div>
+    </transition>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    text: string
+    position?: 'top' | 'bottom' | 'left' | 'right'
+    trigger?: 'hover' | 'click' | 'focus' | 'manual'
+    delay?: number
+    disabled?: boolean
+    persistent?: boolean
+    offset?: number
+    animation?: 'fade' | 'scale' | 'slide-up' | 'slide-down' | 'none'
+    id?: string
+    open?: boolean
+    closeOnClickOutside?: boolean
+    zIndex?: number
+  }>(),
+  {
+    position: 'top',
+    trigger: 'hover',
+    delay: 0,
+    disabled: false,
+    persistent: false,
+    offset: 8,
+    animation: 'fade',
+    closeOnClickOutside: true,
+  }
+)
+
+const emit = defineEmits<{ (e: 'update:open', value: boolean): void }>()
+
+const wrapper = ref<HTMLElement | null>(null)
+const activator = ref<HTMLElement | null>(null)
+const isVisible = ref(false)
+const delayTimeout = ref<number>()
+
+const uid = Math.random().toString(36).slice(2)
+const generatedId = `base-tooltip-${uid}`
+const tooltipId = computed(() => props.id ?? generatedId)
+
+const transitionName = computed(() => {
+  switch (props.animation) {
+    case 'fade':
+      return 'fade'
+    case 'scale':
+      return 'scale'
+    case 'slide-up':
+      return 'slide-top'
+    case 'slide-down':
+      return 'slide-bottom'
+    default:
+      return ''
+  }
+})
+
+const tooltipStyle = computed(() => ({
+  '--tooltip-offset': `${props.offset}px`,
+  ...(props.zIndex !== undefined ? { '--tooltip-z-index': String(props.zIndex) } : {}),
+}))
+
+function show() {
+  if (props.disabled) return
+  clearTimeout(delayTimeout.value)
+  if (props.delay && props.delay > 0) {
+    delayTimeout.value = window.setTimeout(() => {
+      isVisible.value = true
+      emit('update:open', true)
+    }, props.delay)
+  } else {
+    isVisible.value = true
+    emit('update:open', true)
+  }
+}
+
+function hide() {
+  clearTimeout(delayTimeout.value)
+  if (props.persistent) return
+  isVisible.value = false
+  emit('update:open', false)
+}
+
+function toggle() {
+  isVisible.value ? hide() : show()
+}
+
+const listeners = computed(() => {
+  if (props.trigger === 'manual') return {}
+  if (props.trigger === 'click') {
+    return { click: toggle }
+  }
+  if (props.trigger === 'focus') {
+    return { focus: show, blur: hide }
+  }
+  return { mouseenter: show, mouseleave: hide, focus: show, blur: hide }
+})
+
+const activatorAttrs = computed(() => ({
+  'aria-describedby': tooltipId.value,
+  ref: activator,
+}))
+
+function onClickOutside(e: MouseEvent) {
+  if (!wrapper.value?.contains(e.target as Node)) {
+    hide()
+  }
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    hide()
+  }
+}
+
+watch(isVisible, val => {
+  if (val) {
+    if (props.closeOnClickOutside && !props.persistent) {
+      document.addEventListener('mousedown', onClickOutside)
+    }
+    document.addEventListener('keydown', onKeydown)
+  } else {
+    document.removeEventListener('mousedown', onClickOutside)
+    document.removeEventListener('keydown', onKeydown)
+  }
+})
+
+watch(
+  () => props.open,
+  val => {
+    if (props.trigger === 'manual') {
+      if (val) show()
+      else hide()
+    }
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', onClickOutside)
+  document.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<style module src="./BaseTooltip.module.css"></style>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -3,3 +3,4 @@ export { default as BaseSwitch } from './components/BaseSwitch.vue';
 export { default as BaseModal } from './components/BaseModal.vue';
 export { default as BaseTextarea } from './components/BaseTextarea.vue';
 export { default as BaseSelect } from './components/BaseSelect.vue';
+export { default as BaseTooltip } from './components/BaseTooltip.vue';


### PR DESCRIPTION
## Summary
- add reusable, accessible BaseTooltip component with multiple triggers and transitions
- style tooltip with CSS modules and design tokens
- document tooltip usage through comprehensive Storybook stories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68924799c55483219d7a95cca70da9a4