### PR TITLE
feat: add BaseTab component

### DIFF
--- a/ui-library/components/BaseTab.module.css
+++ b/ui-library/components/BaseTab.module.css
@@ -1,0 +1,97 @@
+.tabWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.tabList {
+  display: flex;
+  gap: var(--space-sm);
+  overflow-x: auto;
+}
+
+.tabItem {
+  background: transparent;
+  border: none;
+  padding: var(--space-sm) var(--space-md);
+  color: var(--color-text);
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tabItem:hover:not(.tabItem--disabled) {
+  color: var(--color-primary);
+}
+
+.tabItem--active {
+  color: var(--color-primary);
+}
+
+.tabItem--disabled {
+  color: var(--color-disabled-text);
+  cursor: not-allowed;
+}
+
+.tabIcon {
+  margin-inline-end: var(--space-xs);
+  display: inline-flex;
+}
+
+.stacked {
+  flex-direction: column;
+}
+
+.stacked .tabIcon {
+  margin: 0 0 var(--space-xs);
+}
+
+.tabContent {
+  padding: var(--space-md) 0;
+}
+
+.variant-underline {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.variant-underline .tabItem {
+  border-radius: 0;
+}
+
+.variant-underline .tabItem--active {
+  border-bottom: 2px solid var(--color-primary);
+}
+
+.variant-pill .tabItem--active {
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.variant-card {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.variant-card .tabItem {
+  border: 1px solid var(--color-border);
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.variant-card .tabItem--active {
+  background: var(--color-surface);
+  border-color: var(--color-primary);
+}
+
+.align-start {
+  justify-content: flex-start;
+}
+
+.align-center {
+  justify-content: center;
+}
+
+.align-end {
+  justify-content: flex-end;
+}

--- a/ui-library/components/BaseTab.stories.ts
+++ b/ui-library/components/BaseTab.stories.ts
@@ -1,0 +1,160 @@
+import { ref } from 'vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+import BaseTab from './BaseTab.vue'
+
+const meta: Meta<typeof BaseTab> = {
+  title: 'Navigation/BaseTab',
+  component: BaseTab
+}
+export default meta
+
+// 1. Basic usage
+export const Basic: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('one')
+    return { active }
+  },
+  template: `<BaseTab v-model="active" :tabs="[
+    { value: 'one', label: 'One', content: 'First' },
+    { value: 'two', label: 'Two', content: 'Second' },
+    { value: 'three', label: 'Three', content: 'Third' }
+  ]" />`
+})
+
+// 2. Icon + label tabs with stacked option
+export const IconTabs: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('a')
+    return { active }
+  },
+  template: `<BaseTab v-model="active" stacked :tabs="[
+    { value: 'a', label: 'Apple', icon: '🍎', content: 'Apple' },
+    { value: 'b', label: 'Banana', icon: '🍌', content: 'Banana' },
+    { value: 'c', label: 'Cherry', icon: '🍒', content: 'Cherry' }
+  ]" />`
+})
+
+// 3. Label as component (VNode)
+export const ComponentLabel: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('profile')
+    const Label = { template: '<span style="color:var(--color-primary)"><b>Profile</b></span>' }
+    return { active, Label }
+  },
+  template: `<BaseTab v-model="active" :tabs="[
+    { value: 'home', label: 'Home', content: 'Home' },
+    { value: 'profile', label: Label, content: 'Profile content' }
+  ]" />`
+})
+
+// 4. Disabled tab
+export const Disabled: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('one')
+    return { active }
+  },
+  template: `<BaseTab v-model="active" :tabs="[
+    { value: 'one', label: 'One', content: 'Enabled' },
+    { value: 'two', label: 'Two', disabled: true, content: 'Disabled' },
+    { value: 'three', label: 'Three', content: 'Enabled' }
+  ]" />`
+})
+
+// 5. Lazy loading content
+export const LazyLoading: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('a')
+    return { active }
+  },
+  template: `<BaseTab v-model="active" lazy :tabs="[
+    { value: 'a', label: 'A', content: 'Content A' },
+    { value: 'b', label: 'B', content: 'Content B' },
+    { value: 'c', label: 'C', content: 'Content C' }
+  ]" />`
+})
+
+// 6. Prop-based + slot-based mix
+export const MixedContent: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('a')
+    return { active }
+  },
+  template: `<BaseTab v-model="active" :tabs="[
+    { value: 'a', label: 'Tab A', content: 'Prop content A' },
+    { value: 'b', label: 'Tab B' }
+  ]">
+    <template #tab-b>Slotted content B</template>
+  </BaseTab>`
+})
+
+// 7. Variants
+export const Variants: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active1 = ref('one')
+    const active2 = ref('one')
+    const active3 = ref('one')
+    const tabs = [
+      { value: 'one', label: 'One', content: 'One' },
+      { value: 'two', label: 'Two', content: 'Two' },
+      { value: 'three', label: 'Three', content: 'Three' }
+    ]
+    return { active1, active2, active3, tabs }
+  },
+  template: `<div>
+    <BaseTab v-model="active1" variant="underline" :tabs="tabs" />
+    <BaseTab v-model="active2" variant="pill" :tabs="tabs" />
+    <BaseTab v-model="active3" variant="card" :tabs="tabs" />
+  </div>`
+})
+
+// 8. Transition types
+export const Transitions: StoryFn = (args) => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('one')
+    return { active, args }
+  },
+  template: `<BaseTab v-model="active" v-bind="args" :tabs="[
+    { value: 'one', label: 'One', content: 'One' },
+    { value: 'two', label: 'Two', content: 'Two' }
+  ]" />`
+})
+Transitions.argTypes = { transition: { control: 'select', options: ['fade','slide-left','slide-up','none'] } }
+Transitions.args = { transition: 'fade' }
+
+// 9. Dark theme
+export const DarkTheme: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('one')
+    return { active }
+  },
+  template: `<div data-theme="dark" style="padding:1rem;background:var(--color-background);">
+    <BaseTab v-model="active" :tabs="[
+      { value: 'one', label: 'One', content: 'One' },
+      { value: 'two', label: 'Two', content: 'Two' }
+    ]" />
+  </div>`
+})
+
+// 10. Long list (scrollable)
+export const LongList: StoryFn = () => ({
+  components: { BaseTab },
+  setup() {
+    const active = ref('1')
+    const tabs = Array.from({ length: 15 }, (_, i) => ({
+      value: String(i + 1),
+      label: `Tab ${i + 1}`,
+      content: `Content ${i + 1}`
+    }))
+    return { active, tabs }
+  },
+  template: `<BaseTab v-model="active" :tabs="tabs" />`
+})

--- a/ui-library/components/BaseTab.vue
+++ b/ui-library/components/BaseTab.vue
@@ -1,0 +1,178 @@
+<template>
+  <div :class="$style.tabWrapper">
+    <slot name="prefix" />
+    <div
+      v-if="!$slots.tabs"
+      :class="[
+        $style.tabList,
+        variant !== 'default' && $style[`variant-${variant}`],
+        $style[`align-${align}`]
+      ]"
+      role="tablist"
+    >
+      <button
+        v-for="(tab, idx) in computedTabs"
+        :key="tab.value"
+        :ref="el => tabRefs[idx] = el as HTMLButtonElement"
+        :class="[
+          $style.tabItem,
+          tabClass,
+          {
+            [$style['tabItem--active']]: isActive(tab.value),
+            [$style['tabItem--disabled']]: tab.disabled,
+            [$style.stacked]: stacked
+          }
+        ]"
+        role="tab"
+        :tabindex="tab.disabled ? -1 : isActive(tab.value) ? 0 : -1"
+        :aria-selected="isActive(tab.value)"
+        :disabled="tab.disabled"
+        @click="() => !tab.disabled && setActive(tab.value)"
+        @keydown="e => onKeydown(e, idx)"
+      >
+        <span v-if="tab.icon" :class="$style.tabIcon" aria-hidden="true">{{ tab.icon }}</span>
+        <span v-if="typeof tab.label === 'string' || typeof tab.label === 'number'">
+          {{ tab.label }}
+        </span>
+        <component v-else-if="tab.label" :is="tab.label" />
+      </button>
+    </div>
+    <slot
+      v-else
+      name="tabs"
+      :tabs="computedTabs"
+      :active="active"
+      :select="setActive"
+    />
+    <slot name="suffix" />
+
+    <transition :name="transitionName">
+      <div
+        v-if="currentTab && shouldRender(currentTab.value)"
+        :key="currentTab.value"
+        :class="[$style.tabContent, contentClass]"
+        role="tabpanel"
+      >
+        <component v-if="currentTab.content" :is="currentTab.content" />
+        <slot v-else :name="`tab-${currentTab.value}`" />
+      </div>
+    </transition>
+    <slot v-if="!currentTab" name="default" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted, useSlots } from 'vue'
+
+export interface TabItem {
+  value: string | number
+  label?: string | number | any
+  icon?: string
+  disabled?: boolean
+  content?: any
+}
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string | number
+    tabs?: TabItem[]
+    variant?: 'default' | 'underline' | 'pill' | 'card'
+    align?: 'start' | 'center' | 'end'
+    lazy?: boolean
+    transition?: 'fade' | 'slide-left' | 'slide-up' | 'none'
+    tabClass?: string
+    contentClass?: string
+    stacked?: boolean
+  }>(),
+  {
+    variant: 'default',
+    align: 'start',
+    lazy: false,
+    transition: 'fade',
+    stacked: false
+  }
+)
+
+const emit = defineEmits<{ 'update:modelValue': [string | number] }>()
+
+const slots = useSlots()
+
+const computedTabs = computed<TabItem[]>(() => {
+  if (props.tabs && props.tabs.length) return props.tabs
+  return Object.keys(slots)
+    .filter(k => k.startsWith('tab-'))
+    .map(k => ({ value: k.slice(4), label: k.slice(4) }))
+})
+
+const active = computed({
+  get: () => props.modelValue ?? computedTabs.value[0]?.value,
+  set: v => emit('update:modelValue', v)
+})
+
+const tabRefs = ref<HTMLButtonElement[]>([])
+
+function setActive(v: string | number) {
+  active.value = v
+}
+
+function isActive(v: string | number) {
+  return active.value === v
+}
+
+function onKeydown(e: KeyboardEvent, idx: number) {
+  const enabled = computedTabs.value.filter(t => !t.disabled)
+  const currentIdx = enabled.findIndex(t => t.value === computedTabs.value[idx].value)
+  switch (e.key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      e.preventDefault()
+      setActive(enabled[(currentIdx + 1) % enabled.length].value)
+      break
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      e.preventDefault()
+      setActive(enabled[(currentIdx - 1 + enabled.length) % enabled.length].value)
+      break
+    case 'Home':
+      e.preventDefault()
+      setActive(enabled[0].value)
+      break
+    case 'End':
+      e.preventDefault()
+      setActive(enabled[enabled.length - 1].value)
+      break
+  }
+}
+
+const rendered = ref<Set<string | number>>(new Set())
+
+function shouldRender(v: string | number) {
+  return !props.lazy || rendered.value.has(v)
+}
+
+watch(
+  active,
+  v => {
+    nextTick(() => {
+      const i = computedTabs.value.findIndex(t => t.value === v)
+      if (i !== -1) tabRefs.value[i]?.focus()
+      if (props.lazy) rendered.value.add(v)
+    })
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  if (props.lazy && active.value != null) rendered.value.add(active.value)
+})
+
+const currentTab = computed(() => computedTabs.value.find(t => t.value === active.value))
+
+const transitionName = computed(() => {
+  if (props.transition === 'none') return ''
+  if (props.transition === 'slide-up') return 'slide-top'
+  return props.transition
+})
+</script>
+
+<style module src="./BaseTab.module.css"></style>

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -4,3 +4,4 @@ export { default as BaseModal } from './components/BaseModal.vue';
 export { default as BaseTextarea } from './components/BaseTextarea.vue';
 export { default as BaseSelect } from './components/BaseSelect.vue';
 export { default as BaseTooltip } from './components/BaseTooltip.vue';
+export { default as BaseTab } from './components/BaseTab.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseTab component with keyboard navigation and theming
- provide styles and stories demonstrating variants and transitions

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: vite: Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_68924a35e7d88321b1deb4549c74ab47