### PR TITLE
feat: add BaseCollapse component

### DIFF
--- a/ui-library/components/BaseCollapse.module.css
+++ b/ui-library/components/BaseCollapse.module.css
@@ -1,0 +1,47 @@
+.collapseWrapper {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.collapseHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-md);
+  cursor: pointer;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  transition: background-color var(--transition-base);
+}
+
+.collapseHeader:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.collapseIcon {
+  display: flex;
+  align-items: center;
+  margin-inline-start: var(--space-sm);
+  transition: transform var(--transition-base);
+}
+
+.collapseContent {
+  padding: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+}
+
+.isOpen .collapseIcon[data-open="true"] {
+  transform: rotate(180deg);
+}
+
+.isDisabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.collapseEnter {}
+.collapseLeave {}

--- a/ui-library/components/BaseCollapse.stories.ts
+++ b/ui-library/components/BaseCollapse.stories.ts
@@ -1,0 +1,123 @@
+import BaseCollapse, { BaseCollapseGroup } from './BaseCollapse.vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+const meta: Meta<typeof BaseCollapse> = {
+  title: 'DataDisplay/BaseCollapse',
+  component: BaseCollapse,
+  args: {
+    title: 'عنوان',
+    modelValue: false,
+    transition: 'collapse',
+    showArrow: true,
+    lazy: false,
+    disabled: false,
+    toggleOnHeaderClick: true,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    modelValue: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    transition: { control: 'select', options: ['collapse', 'fade', 'slide-down', 'none'] },
+    showArrow: { control: 'boolean' },
+    lazy: { control: 'boolean' },
+    toggleOnHeaderClick: { control: 'boolean' },
+  },
+}
+export default meta
+
+const Template: StoryFn<typeof BaseCollapse> = (args) => ({
+  components: { BaseCollapse },
+  setup: () => ({ args }),
+  template: `<BaseCollapse v-bind="args"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>`
+})
+export const Default = Template.bind({})
+
+export const SlotHeader: StoryFn<typeof BaseCollapse> = (args) => ({
+  components: { BaseCollapse },
+  setup: () => ({ args }),
+  template: `
+  <BaseCollapse v-bind="args">
+    <template #header><strong>سربرگ سفارشی</strong></template>
+    <p style="padding:var(--space-md);">محتوا</p>
+  </BaseCollapse>`
+})
+
+export const WithIcon: StoryFn<typeof BaseCollapse> = (args) => ({
+  components: { BaseCollapse },
+  setup: () => ({ args }),
+  template: `<BaseCollapse v-bind="args" icon="fa fa-info"><p style="padding:var(--space-md);">با آیکن</p></BaseCollapse>`
+})
+
+export const LazyContent: StoryFn<typeof BaseCollapse> = (args) => ({
+  components: { BaseCollapse },
+  setup: () => ({ args }),
+  template: `<BaseCollapse v-bind="args" lazy><p style="padding:var(--space-md);">بارگذاری تنبل</p></BaseCollapse>`
+})
+
+export const AccordionGroup: StoryFn = () => ({
+  components: { BaseCollapseGroup },
+  setup() {
+    const expanded = ref<string[]>(['one'])
+    const items = [
+      { key: 'one', title: 'آیتم یک', content: 'متن یک' },
+      { key: 'two', title: 'آیتم دو', content: 'متن دو' },
+      { key: 'three', title: 'آیتم سه', content: 'متن سه', disabled: true },
+    ]
+    return { expanded, items }
+  },
+  template: `<BaseCollapseGroup v-model="expanded" :accordion="true" :items="items" />`
+})
+
+export const MultipleOpen: StoryFn = () => ({
+  components: { BaseCollapseGroup },
+  setup() {
+    const expanded = ref<string[]>(['one'])
+    const items = [
+      { key: 'one', title: 'آیتم یک', content: 'متن یک' },
+      { key: 'two', title: 'آیتم دو', content: 'متن دو' },
+      { key: 'three', title: 'آیتم سه', content: 'متن سه' },
+    ]
+    return { expanded, items }
+  },
+  template: `<BaseCollapseGroup v-model="expanded" :accordion="false" :items="items" />`
+})
+
+export const Transitions: StoryFn = () => ({
+  components: { BaseCollapse },
+  template: `
+  <div style="display:flex;flex-direction:column;gap:var(--space-md);max-width:300px;">
+    <BaseCollapse title="Collapse" transition="collapse"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+    <BaseCollapse title="Fade" transition="fade"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+    <BaseCollapse title="Slide" transition="slide-down"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+    <BaseCollapse title="None" transition="none"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+  </div>`
+})
+
+export const DarkTheme: StoryFn = () => ({
+  components: { BaseCollapse },
+  template: `
+  <div data-theme="dark" style="padding:var(--space-md);background:var(--color-surface);">
+    <BaseCollapse title="دارک مود"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+  </div>`
+})
+
+export const Disabled: StoryFn<typeof BaseCollapse> = (args) => ({
+  components: { BaseCollapse },
+  setup: () => ({ args }),
+  template: `<BaseCollapse v-bind="args" disabled><p style="padding:var(--space-md);">غیرفعال</p></BaseCollapse>`
+})
+
+export const Controlled: StoryFn = () => ({
+  components: { BaseCollapse },
+  setup() {
+    const open = ref(false)
+    const toggle = () => (open.value = !open.value)
+    return { open, toggle }
+  },
+  template: `
+  <div>
+    <button @click="toggle" style="margin-bottom:var(--space-sm);">تغییر</button>
+    <BaseCollapse v-model="open" title="کنترل شده"><p style="padding:var(--space-md);">محتوا</p></BaseCollapse>
+  </div>`
+})

--- a/ui-library/components/BaseCollapse.vue
+++ b/ui-library/components/BaseCollapse.vue
@@ -1,0 +1,244 @@
+<template>
+  <div :class="[styles.collapseWrapper, isOpen && styles.isOpen, disabled && styles.isDisabled]">
+    <div
+      :class="styles.collapseHeader"
+      role="button"
+      :aria-expanded="isOpen"
+      :aria-controls="contentId"
+      tabindex="0"
+      @click="onHeaderClick"
+      @keydown="onKeydown"
+    >
+      <slot name="header">
+        <span v-if="icon" :class="styles.collapseIcon">
+          <i v-if="isIconString" :class="iconString" />
+          <component v-else :is="iconVNode" />
+        </span>
+        <span>{{ title }}</span>
+      </slot>
+      <span v-if="showArrow" :class="styles.collapseIcon" :data-open="isOpen">
+        <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+          <path fill="currentColor" d="M7 10l5 5 5-5z" />
+        </svg>
+      </span>
+    </div>
+    <Transition
+      :name="transitionName"
+      :css="transitionName !== ''"
+      v-on="collapseTransition"
+    >
+      <div
+        v-if="hasRendered"
+        v-show="isOpen"
+        :id="contentId"
+        :class="styles.collapseContent"
+      >
+        <slot />
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  ref,
+  watch,
+  computed,
+  withDefaults,
+  defineProps,
+  defineEmits,
+  VNode,
+  PropType,
+  defineComponent,
+  h,
+  getCurrentInstance,
+} from 'vue';
+import styles from './BaseCollapse.module.css';
+
+type TransitionType = 'collapse' | 'fade' | 'slide-down' | 'none';
+
+const props = withDefaults(
+  defineProps<{
+    title?: string | VNode;
+    modelValue?: boolean;
+    disabled?: boolean;
+    transition?: TransitionType;
+    icon?: string | VNode;
+    showArrow?: boolean;
+    lazy?: boolean;
+    toggleOnHeaderClick?: boolean;
+  }>(),
+  {
+    modelValue: false,
+    disabled: false,
+    transition: 'collapse',
+    icon: undefined,
+    showArrow: true,
+    lazy: false,
+    toggleOnHeaderClick: true,
+  }
+);
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>();
+
+const isOpen = ref<boolean>(props.modelValue);
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (val !== undefined) isOpen.value = val;
+  }
+);
+watch(isOpen, (val) => emit('update:modelValue', val));
+
+const hasRendered = ref(!props.lazy || isOpen.value);
+watch(isOpen, (val) => {
+  if (val) hasRendered.value = true;
+});
+
+const contentId = `collapse-content-${Math.random().toString(36).slice(2, 9)}`;
+
+const transitionName = computed(() => {
+  switch (props.transition) {
+    case 'fade':
+      return 'fade';
+    case 'slide-down':
+      return 'slide-bottom';
+    case 'none':
+      return '';
+    default:
+      return 'collapse';
+  }
+});
+
+function onHeaderClick() {
+  if (props.disabled || !props.toggleOnHeaderClick) return;
+  isOpen.value = !isOpen.value;
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    if (!props.disabled) isOpen.value = !isOpen.value;
+  }
+}
+
+const isIconString = computed(() => typeof props.icon === 'string');
+const iconString = computed(() =>
+  isIconString.value ? (props.icon as string) : ''
+);
+const iconVNode = computed(() =>
+  isIconString.value || !props.icon ? null : (props.icon as VNode)
+);
+
+const isCollapse = computed(() => transitionName.value === 'collapse');
+
+function setMaxHeight(el: HTMLElement) {
+  el.style.setProperty('--collapse-max-height', `${el.scrollHeight}px`);
+}
+
+const collapseTransition = {
+  onBeforeEnter: (el: Element) => {
+    if (isCollapse.value) setMaxHeight(el as HTMLElement);
+  },
+  onBeforeLeave: (el: Element) => {
+    if (isCollapse.value) setMaxHeight(el as HTMLElement);
+  },
+  onAfterEnter: (el: Element) => {
+    if (isCollapse.value) (el as HTMLElement).style.removeProperty('--collapse-max-height');
+  },
+  onAfterLeave: (el: Element) => {
+    if (isCollapse.value) (el as HTMLElement).style.removeProperty('--collapse-max-height');
+  },
+};
+
+// Group component
+const self = getCurrentInstance();
+const BaseCollapseComponent = self!.type as any;
+
+export const BaseCollapseGroup = defineComponent({
+  name: 'BaseCollapseGroup',
+  props: {
+    modelValue: {
+      type: Array as PropType<string[]>,
+      default: undefined,
+    },
+    accordion: {
+      type: Boolean,
+      default: false,
+    },
+    items: {
+      type: Array as PropType<Array<{
+        key: string;
+        title: string | VNode;
+        content?: VNode | string;
+        disabled?: boolean;
+        icon?: string | VNode;
+      }>>,
+      default: () => [],
+    },
+    transition: {
+      type: String as PropType<TransitionType>,
+      default: 'collapse',
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(groupProps, { emit, slots }) {
+    const openKeys = ref<string[]>(groupProps.modelValue ? [...groupProps.modelValue] : []);
+
+    watch(
+      () => groupProps.modelValue,
+      (val) => {
+        openKeys.value = val ? [...val] : [];
+      }
+    );
+
+    function update(keys: string[]) {
+      openKeys.value = keys;
+      emit('update:modelValue', keys);
+    }
+
+    function toggle(key: string, val: boolean) {
+      let keys = [...openKeys.value];
+      if (groupProps.accordion) {
+        keys = val ? [key] : [];
+      } else {
+        const idx = keys.indexOf(key);
+        if (val) {
+          if (idx === -1) keys.push(key);
+        } else if (idx !== -1) {
+          keys.splice(idx, 1);
+        }
+      }
+      update(keys);
+    }
+
+    return () =>
+      h('div', {},
+        groupProps.items.map((item) => {
+          const contentSlot = slots[`item-${item.key}`];
+          const iconSlot = slots[`icon-${item.key}`];
+          const iconVNode = iconSlot ? iconSlot()[0] : item.icon;
+          return h(
+            BaseCollapseComponent,
+            {
+              key: item.key,
+              title: item.title,
+              icon: iconVNode as any,
+              modelValue: openKeys.value.includes(item.key),
+              transition: groupProps.transition,
+              disabled: item.disabled,
+              onUpdate:modelValue: (val: boolean) => toggle(item.key, val),
+            },
+            contentSlot
+              ? { default: () => contentSlot() }
+              : item.content
+              ? { default: () => item.content as any }
+              : undefined
+          );
+        })
+      );
+  },
+});
+</script>
+
+<style module src="./BaseCollapse.module.css"></style>


### PR DESCRIPTION
## Summary
- add reusable `BaseCollapse` with accessible header and transition support
- support grouped accordions via `BaseCollapseGroup`
- document usage through Storybook stories

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68944ba868d48321bf1ebc03635b2b25