### PR TITLE
feat: add BaseRadio component

### DIFF
--- a/ui-library/components/BaseRadio/BaseRadio.module.css
+++ b/ui-library/components/BaseRadio/BaseRadio.module.css
@@ -1,0 +1,118 @@
+.wrapper {
+  --radio-size: 1.25rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.inline {
+  display: inline-flex;
+}
+
+.input {
+  position: absolute;
+  opacity: 0;
+  width: var(--radio-size);
+  height: var(--radio-size);
+  margin: 0;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  cursor: pointer;
+  user-select: none;
+  color: var(--color-text);
+  font-size: var(--font-size-md);
+}
+
+.control {
+  width: var(--radio-size);
+  height: var(--radio-size);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-background);
+  box-sizing: border-box;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.dot {
+  width: calc(var(--radio-size) / 2);
+  height: calc(var(--radio-size) / 2);
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  transform: scale(0);
+  transition: transform var(--transition-fast);
+}
+
+.input:checked + .label .control {
+  border-color: var(--color-primary);
+}
+
+.input:checked + .label .control .dot {
+  transform: scale(1);
+}
+
+.input:focus-visible + .label .control {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.text {
+  line-height: 1;
+}
+
+.required {
+  margin-left: 2px;
+  color: var(--color-error);
+}
+
+.disabled .label {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.disabled .control {
+  background: var(--color-disabled-bg);
+  border-color: var(--color-border);
+}
+
+.disabled .input:checked + .label .control .dot {
+  background: var(--color-disabled-text);
+}
+
+.error .label {
+  color: var(--color-error);
+}
+
+.error .control {
+  border-color: var(--color-error);
+}
+
+.error .input:checked + .label .control .dot {
+  background: var(--color-error);
+}
+
+.sm {
+  --radio-size: 1rem;
+}
+
+.sm .label {
+  font-size: var(--font-size-sm);
+}
+
+.md {
+  --radio-size: 1.25rem;
+}
+
+.lg {
+  --radio-size: 1.5rem;
+}
+
+.lg .label {
+  font-size: var(--font-size-lg);
+}

--- a/ui-library/components/BaseRadio/BaseRadio.stories.ts
+++ b/ui-library/components/BaseRadio/BaseRadio.stories.ts
@@ -1,0 +1,134 @@
+import { ref, watch } from 'vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+import BaseRadio from './BaseRadio.vue'
+
+const meta: Meta<typeof BaseRadio> = {
+  title: 'Form/BaseRadio',
+  component: BaseRadio,
+  args: {
+    modelValue: '',
+    value: 'option1',
+    label: 'Option 1',
+    name: 'example',
+    disabled: false,
+    error: false,
+    required: false,
+    inline: false,
+    ariaLabel: 'Option',
+    size: 'md'
+  },
+  argTypes: {
+    modelValue: { control: 'text' },
+    value: { control: 'text' },
+    label: { control: 'text' },
+    name: { control: 'text' },
+    disabled: { control: 'boolean' },
+    error: { control: 'boolean' },
+    required: { control: 'boolean' },
+    inline: { control: 'boolean' },
+    ariaLabel: { control: 'text' },
+    size: { control: { type: 'select', options: ['sm', 'md', 'lg'] } }
+  },
+  decorators: [
+    () => ({ template: '<div style="padding:2rem"><story /></div>' })
+  ],
+  parameters: {
+    layout: 'centered',
+    controls: { expanded: true }
+  }
+}
+export default meta
+
+const Template: StoryFn<typeof BaseRadio> = (args) => ({
+  components: { BaseRadio },
+  setup() {
+    const val = ref(args.modelValue)
+    watch(() => args.modelValue, (v) => (val.value = v))
+    return { args, val }
+  },
+  template: '<BaseRadio v-bind="args" v-model="val" />'
+})
+
+export const Default = Template.bind({})
+Default.parameters = {
+  docs: { description: { story: 'Unselected radio button.' } }
+}
+
+export const Checked = Template.bind({})
+Checked.args = { modelValue: 'option1' }
+Checked.parameters = {
+  docs: { description: { story: 'Radio starts checked via v-model.' } }
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = { disabled: true }
+Disabled.parameters = {
+  docs: { description: { story: 'User cannot interact with disabled radio.' } }
+}
+
+export const Error = Template.bind({})
+Error.args = { error: true, label: 'Error state' }
+Error.parameters = {
+  docs: { description: { story: 'Shows error styling.' } }
+}
+
+export const WithLabel = Template.bind({})
+WithLabel.args = { label: 'Labeled radio' }
+WithLabel.parameters = {
+  docs: { description: { story: 'Radio with visible label.' } }
+}
+
+export const WithoutLabel = Template.bind({})
+WithoutLabel.args = { label: '', ariaLabel: 'No label radio' }
+WithoutLabel.parameters = {
+  docs: { description: { story: 'Accessible using aria-label when no label text.' } }
+}
+
+export const InlineGroup: StoryFn<typeof BaseRadio> = (args) => ({
+  components: { BaseRadio },
+  setup() {
+    const val = ref('one')
+    return { args, val }
+  },
+  template: `
+    <div style="display:flex; gap:1rem;">
+      <BaseRadio v-bind="args" v-model="val" value="one" label="One" inline name="inline" />
+      <BaseRadio v-bind="args" v-model="val" value="two" label="Two" inline name="inline" />
+      <BaseRadio v-bind="args" v-model="val" value="three" label="Three" inline name="inline" />
+    </div>
+  `
+})
+InlineGroup.storyName = 'Inline radios in group'
+InlineGroup.parameters = {
+  docs: { description: { story: 'Multiple radios displayed horizontally.' } }
+}
+
+export const Sizes: StoryFn<typeof BaseRadio> = (args) => ({
+  components: { BaseRadio },
+  setup() {
+    const val = ref('md')
+    return { args, val }
+  },
+  template: `
+    <div style="display:flex; flex-direction:column; gap:1rem;">
+      <BaseRadio v-bind="args" v-model="val" value="sm" label="Small" size="sm" />
+      <BaseRadio v-bind="args" v-model="val" value="md" label="Medium" size="md" />
+      <BaseRadio v-bind="args" v-model="val" value="lg" label="Large" size="lg" />
+    </div>
+  `
+})
+Sizes.storyName = 'Custom size (sm / md / lg)'
+Sizes.parameters = {
+  docs: { description: { story: 'Demonstrates all size options.' } }
+}
+
+export const KeyboardAccessible = Template.bind({})
+KeyboardAccessible.parameters = {
+  docs: { description: { story: 'Focusable and toggled via keyboard (Tab + Space/Enter).' } }
+}
+
+export const RequiredField = Template.bind({})
+RequiredField.args = { required: true, label: 'Required choice' }
+RequiredField.parameters = {
+  docs: { description: { story: 'Adds required indicator to the label.' } }
+}

--- a/ui-library/components/BaseRadio/BaseRadio.vue
+++ b/ui-library/components/BaseRadio/BaseRadio.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { withDefaults, defineProps, defineEmits, computed } from 'vue'
+import styles from './BaseRadio.module.css'
+
+const props = withDefaults(defineProps<{
+  modelValue: string | number | boolean
+  value: string | number | boolean
+  label?: string
+  name?: string
+  disabled?: boolean
+  error?: boolean
+  required?: boolean
+  inline?: boolean
+  id?: string
+  ariaLabel?: string
+  size?: 'sm' | 'md' | 'lg'
+}>(), {
+  disabled: false,
+  error: false,
+  required: false,
+  inline: false,
+  size: 'md'
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | number | boolean): void
+  (e: 'change', event: Event): void
+}>()
+
+const internalId = props.id || `radio-${Math.random().toString(36).slice(2, 9)}`
+
+const isChecked = computed(() => props.modelValue === props.value)
+
+function onChange(e: Event) {
+  if (props.disabled) return
+  emit('update:modelValue', props.value)
+  emit('change', e)
+}
+</script>
+
+<template>
+  <div
+    :class="[
+      styles.wrapper,
+      styles[size],
+      inline && styles.inline,
+      disabled && styles.disabled,
+      error && styles.error
+    ]"
+  >
+    <input
+      :id="internalId"
+      :name="name"
+      :value="value"
+      :checked="isChecked"
+      :disabled="disabled"
+      :required="required"
+      :aria-label="ariaLabel"
+      type="radio"
+      :class="styles.input"
+      @change="onChange"
+    />
+    <label :for="internalId" :class="styles.label">
+      <span :class="styles.control">
+        <span :class="styles.dot"></span>
+      </span>
+      <span v-if="label" :class="styles.text">
+        {{ label }}
+        <span v-if="required" :class="styles.required">*</span>
+      </span>
+    </label>
+  </div>
+</template>
+
+<style module src="./BaseRadio.module.css"></style>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -5,6 +5,7 @@ export { default as BaseDropdown } from './BaseDropdown/BaseDropdown.vue';
 export { default as BaseInput } from './BaseInput/BaseInput.vue';
 export { default as BaseModal } from './BaseModal/BaseModal.vue';
 export { default as BaseSelect } from './BaseSelect/BaseSelect.vue';
+export { default as BaseRadio } from './BaseRadio/BaseRadio.vue';
 export { default as BaseSwitch } from './BaseSwitch/BaseSwitch.vue';
 export { default as BaseTab } from './BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';

--- a/ui-library/types/index.d.ts
+++ b/ui-library/types/index.d.ts
@@ -5,6 +5,7 @@ export { default as BaseDropdown } from '../components/BaseDropdown/BaseDropdown
 export { default as BaseInput } from '../components/BaseInput/BaseInput.vue';
 export { default as BaseModal } from '../components/BaseModal/BaseModal.vue';
 export { default as BaseSelect } from '../components/BaseSelect/BaseSelect.vue';
+export { default as BaseRadio } from '../components/BaseRadio/BaseRadio.vue';
 export { default as BaseSwitch } from '../components/BaseSwitch/BaseSwitch.vue';
 export { default as BaseTab } from '../components/BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from '../components/BaseTextarea/BaseTextarea.vue';


### PR DESCRIPTION
## Summary
- add fully featured BaseRadio Vue component with accessibility and size options
- style radios via CSS modules and theme variables for states
- showcase radio behavior and variants in Storybook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689456191ba48321a961217554406b4e