### PR TITLE
feat: add rich text editor component

### DIFF
--- a/ui-library/components/RichTextEditor/RichTextEditor.module.css
+++ b/ui-library/components/RichTextEditor/RichTextEditor.module.css
@@ -1,0 +1,25 @@
+.wrapper {
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+}
+
+.editor {
+  min-height: 200px;
+  padding: var(--space-md);
+  line-height: 1.5;
+  outline: none;
+}
+
+.editor:empty:before {
+  content: attr(data-placeholder);
+  color: var(--color-muted);
+  pointer-events: none;
+}
+
+.editor[contenteditable='false'] {
+  background: var(--color-disabled-bg);
+  color: var(--color-disabled-text);
+}

--- a/ui-library/components/RichTextEditor/RichTextEditor.stories.ts
+++ b/ui-library/components/RichTextEditor/RichTextEditor.stories.ts
@@ -1,0 +1,39 @@
+import RichTextEditor from './RichTextEditor.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof RichTextEditor> = {
+  title: 'Form/RichTextEditor',
+  component: RichTextEditor,
+  argTypes: {
+    content: { control: 'text' },
+    placeholder: { control: 'text' },
+    readonly: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    theme: { control: 'select', options: ['light', 'dark'] },
+  },
+  args: {
+    content: '',
+    placeholder: 'Start typing...',
+    readonly: false,
+    disabled: false,
+    theme: 'light',
+  }
+}
+export default meta
+
+type Story = StoryObj<typeof RichTextEditor>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { RichTextEditor },
+    setup() { return { args } },
+    template: `<div :data-theme="args.theme" style="max-width: 600px;">
+      <RichTextEditor v-model:content="args.content" :placeholder="args.placeholder" :readonly="args.readonly" :disabled="args.disabled" />
+    </div>`
+  })
+}
+
+export const Mobile: Story = {
+  ...Default,
+  parameters: { viewport: { defaultViewport: 'mobile1' } }
+}

--- a/ui-library/components/RichTextEditor/RichTextEditor.vue
+++ b/ui-library/components/RichTextEditor/RichTextEditor.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import Toolbar from './Toolbar.vue'
+import styles from './RichTextEditor.module.css'
+import { useCommands, detectFormats, type Command } from './commands'
+
+const props = withDefaults(defineProps<{
+  content?: string
+  placeholder?: string
+  readonly?: boolean
+  disabled?: boolean
+}>(), {
+  content: ''
+})
+
+const emit = defineEmits<{(
+  e: 'update:content', value: string
+): void; (e: 'focus'): void; (e: 'blur'): void }>()
+
+const editorRef = ref<HTMLDivElement>()
+const active = ref<Set<Command>>(new Set())
+const history = ref<string[]>([])
+const historyIndex = ref(-1)
+
+const { exec } = useCommands(editorRef)
+
+const pushHistory = () => {
+  if (!editorRef.value) return
+  const html = editorRef.value.innerHTML
+  history.value = history.value.slice(0, historyIndex.value + 1)
+  history.value.push(html)
+  historyIndex.value++
+}
+
+const undo = () => {
+  if (historyIndex.value > 0) {
+    historyIndex.value--
+    editorRef.value!.innerHTML = history.value[historyIndex.value]
+    emit('update:content', editorRef.value!.innerHTML)
+  }
+}
+
+const redo = () => {
+  if (historyIndex.value < history.value.length - 1) {
+    historyIndex.value++
+    editorRef.value!.innerHTML = history.value[historyIndex.value]
+    emit('update:content', editorRef.value!.innerHTML)
+  }
+}
+
+const handleCommand = (cmd: Command, value?: string) => {
+  if (cmd === 'undo') return undo()
+  if (cmd === 'redo') return redo()
+  if (cmd === 'link' && !value) value = prompt('Enter URL') || undefined
+  if (cmd === 'image' && !value) value = prompt('Enter image URL') || undefined
+  exec(cmd, value)
+  emit('update:content', editorRef.value?.innerHTML || '')
+  pushHistory()
+  updateActive()
+}
+
+const updateActive = () => {
+  active.value = detectFormats()
+}
+
+const onInput = () => {
+  emit('update:content', editorRef.value?.innerHTML || '')
+  pushHistory()
+}
+
+const onPaste = (e: ClipboardEvent) => {
+  e.preventDefault()
+  const text = e.clipboardData?.getData('text/plain') || ''
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return
+  const range = sel.getRangeAt(0)
+  range.deleteContents()
+  range.insertNode(document.createTextNode(text))
+  range.collapse(false)
+  emit('update:content', editorRef.value?.innerHTML || '')
+  pushHistory()
+}
+
+watch(() => props.content, (val) => {
+  if (editorRef.value && editorRef.value.innerHTML !== val) {
+    editorRef.value.innerHTML = val || ''
+  }
+})
+
+onMounted(() => {
+  if (props.content && editorRef.value) {
+    editorRef.value.innerHTML = props.content
+  }
+  pushHistory()
+  document.addEventListener('selectionchange', updateActive)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('selectionchange', updateActive)
+})
+
+const onKey = (e: KeyboardEvent) => {
+  if (!e.ctrlKey && !e.metaKey) return
+  switch (e.key.toLowerCase()) {
+    case 'b':
+      e.preventDefault()
+      handleCommand('bold')
+      break
+    case 'i':
+      e.preventDefault()
+      handleCommand('italic')
+      break
+    case 'u':
+      e.preventDefault()
+      handleCommand('underline')
+      break
+    case 'z':
+      e.preventDefault()
+      undo()
+      break
+    case 'y':
+      e.preventDefault()
+      redo()
+      break
+  }
+}
+</script>
+
+<template>
+  <div :class="styles.wrapper" :data-readonly="readonly" :data-disabled="disabled">
+    <slot name="toolbar" :active="active" :command="handleCommand">
+      <Toolbar :disabled="disabled || readonly" :active="active" @command="handleCommand" />
+    </slot>
+    <div
+      ref="editorRef"
+      :class="styles.editor"
+      :contenteditable="!readonly && !disabled"
+      :data-placeholder="placeholder"
+      @input="onInput"
+      @paste="onPaste"
+      @keydown="onKey"
+      @focus="() => emit('focus')"
+      @blur="() => emit('blur')"
+    ></div>
+  </div>
+</template>

--- a/ui-library/components/RichTextEditor/Toolbar.module.css
+++ b/ui-library/components/RichTextEditor/Toolbar.module.css
@@ -1,0 +1,40 @@
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding: var(--space-xs);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.button {
+  border: none;
+  background: transparent;
+  padding: var(--space-xs);
+  cursor: pointer;
+  color: var(--color-text);
+  transition: background var(--transition-fast, 0.2s);
+  border-radius: var(--radius-sm);
+}
+
+.button:hover {
+  background: var(--color-border);
+}
+
+.button.active {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.color {
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+}

--- a/ui-library/components/RichTextEditor/Toolbar.vue
+++ b/ui-library/components/RichTextEditor/Toolbar.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import styles from './Toolbar.module.css'
+import type { Command } from './commands'
+
+const props = defineProps<{ active: Set<Command>; disabled?: boolean }>()
+const emit = defineEmits<{ (e: 'command', cmd: Command, value?: string): void }>()
+
+const isActive = (cmd: Command) => props.active.has(cmd)
+</script>
+
+<template>
+  <div :class="styles.toolbar">
+    <select :disabled="props.disabled" @change="emit('command', $event.target.value)">
+      <option value="p">P</option>
+      <option value="h1">H1</option>
+      <option value="h2">H2</option>
+      <option value="h3">H3</option>
+      <option value="blockquote">Quote</option>
+      <option value="code">Code</option>
+    </select>
+    <button :class="[styles.button, isActive('bold') && styles.active]" :disabled="props.disabled" @click="emit('command','bold')"><strong>B</strong></button>
+    <button :class="[styles.button, isActive('italic') && styles.active]" :disabled="props.disabled" @click="emit('command','italic')"><em>I</em></button>
+    <button :class="[styles.button, isActive('underline') && styles.active]" :disabled="props.disabled" @click="emit('command','underline')"><u>U</u></button>
+    <button :class="[styles.button, isActive('strike') && styles.active]" :disabled="props.disabled" @click="emit('command','strike')"><s>S</s></button>
+    <button :class="[styles.button, isActive('orderedList') && styles.active]" :disabled="props.disabled" @click="emit('command','orderedList')">OL</button>
+    <button :class="[styles.button, isActive('unorderedList') && styles.active]" :disabled="props.disabled" @click="emit('command','unorderedList')">UL</button>
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','link')">🔗</button>
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','image')">🖼️</button>
+    <button :class="[styles.button, isActive('alignLeft') && styles.active]" :disabled="props.disabled" @click="emit('command','alignLeft')">⯇</button>
+    <button :class="[styles.button, isActive('alignCenter') && styles.active]" :disabled="props.disabled" @click="emit('command','alignCenter')">≡</button>
+    <button :class="[styles.button, isActive('alignRight') && styles.active]" :disabled="props.disabled" @click="emit('command','alignRight')">⯈</button>
+    <input type="color" :disabled="props.disabled" @input="emit('command','textColor', ($event.target as HTMLInputElement).value)" class="styles.color" />
+    <input type="color" :disabled="props.disabled" @input="emit('command','backgroundColor', ($event.target as HTMLInputElement).value)" class="styles.color" />
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','undo')">↺</button>
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','redo')">↻</button>
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','hr')">―</button>
+    <button :class="styles.button" :disabled="props.disabled" @click="emit('command','clear')">✖</button>
+  </div>
+</template>

--- a/ui-library/components/RichTextEditor/commands.ts
+++ b/ui-library/components/RichTextEditor/commands.ts
@@ -1,0 +1,182 @@
+import type { Ref } from 'vue'
+
+export type Command =
+  | 'bold' | 'italic' | 'underline' | 'strike'
+  | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'blockquote' | 'code'
+  | 'orderedList' | 'unorderedList'
+  | 'link' | 'image' | 'hr'
+  | 'alignLeft' | 'alignCenter' | 'alignRight' | 'alignJustify'
+  | 'textColor' | 'backgroundColor'
+  | 'clear'
+
+export function useCommands(editorRef: Ref<HTMLElement | undefined>) {
+  const getRange = () => {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) return null
+    return sel.getRangeAt(0)
+  }
+
+  const wrapInline = (tag: string, attrs?: Record<string, string>) => {
+    const range = getRange()
+    if (!range || range.collapsed) return
+    const el = document.createElement(tag)
+    if (attrs) Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v))
+    range.surroundContents(el)
+  }
+
+  const setBlock = (tag: string) => {
+    const range = getRange()
+    if (!range) return
+    let node = range.startContainer as HTMLElement
+    if (node.nodeType === 3) node = node.parentElement as HTMLElement
+    const block = node.closest('p,div,blockquote,h1,h2,h3,h4,h5,h6,pre,li') as HTMLElement
+    if (!block) return
+    const newEl = document.createElement(tag)
+    newEl.innerHTML = block.innerHTML
+    block.replaceWith(newEl)
+  }
+
+  const insertList = (ordered: boolean) => {
+    const range = getRange()
+    if (!range) return
+    let node = range.startContainer as HTMLElement
+    if (node.nodeType === 3) node = node.parentElement as HTMLElement
+    const block = node.closest('p,div,h1,h2,h3,h4,h5,h6,blockquote,pre') as HTMLElement
+    if (!block) return
+    const li = document.createElement('li')
+    li.innerHTML = block.innerHTML
+    const list = document.createElement(ordered ? 'ol' : 'ul')
+    list.appendChild(li)
+    block.replaceWith(list)
+  }
+
+  const insertLink = (url: string) => wrapInline('a', { href: url, target: '_blank' })
+
+  const insertImage = (src: string) => {
+    const range = getRange()
+    if (!range) return
+    const img = document.createElement('img')
+    img.src = src
+    range.insertNode(img)
+  }
+
+  const insertHr = () => {
+    const range = getRange()
+    if (!range) return
+    const hr = document.createElement('hr')
+    range.insertNode(hr)
+  }
+
+  const setAlign = (align: string) => {
+    const range = getRange()
+    if (!range) return
+    let node = range.startContainer as HTMLElement
+    if (node.nodeType === 3) node = node.parentElement as HTMLElement
+    const block = node.closest('p,div,blockquote,h1,h2,h3,h4,h5,h6,li,pre') as HTMLElement
+    if (block) block.style.textAlign = align
+  }
+
+  const wrapColor = (prop: 'color' | 'background-color', value: string) =>
+    wrapInline('span', { style: `${prop}:${value}` })
+
+  const clear = () => {
+    const editor = editorRef.value
+    if (editor) {
+      editor.innerText = editor.innerText
+    }
+  }
+
+  const exec = (cmd: Command, value?: string) => {
+    switch (cmd) {
+      case 'bold':
+        wrapInline('strong')
+        break
+      case 'italic':
+        wrapInline('em')
+        break
+      case 'underline':
+        wrapInline('u')
+        break
+      case 'strike':
+        wrapInline('s')
+        break
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+      case 'p':
+      case 'blockquote':
+        setBlock(cmd)
+        break
+      case 'code':
+        setBlock('pre')
+        break
+      case 'orderedList':
+        insertList(true)
+        break
+      case 'unorderedList':
+        insertList(false)
+        break
+      case 'link':
+        value && insertLink(value)
+        break
+      case 'image':
+        value && insertImage(value)
+        break
+      case 'hr':
+        insertHr()
+        break
+      case 'alignLeft':
+        setAlign('left')
+        break
+      case 'alignCenter':
+        setAlign('center')
+        break
+      case 'alignRight':
+        setAlign('right')
+        break
+      case 'alignJustify':
+        setAlign('justify')
+        break
+      case 'textColor':
+        value && wrapColor('color', value)
+        break
+      case 'backgroundColor':
+        value && wrapColor('background-color', value)
+        break
+      case 'clear':
+        clear()
+        break
+    }
+  }
+
+  return { exec }
+}
+
+export function detectFormats(): Set<Command> {
+  const sel = window.getSelection()
+  const set = new Set<Command>()
+  if (!sel || sel.rangeCount === 0) return set
+  let node = sel.anchorNode as HTMLElement
+  if (node.nodeType === 3) node = node.parentElement as HTMLElement
+  if (!node) return set
+  if (node.closest('strong')) set.add('bold')
+  if (node.closest('em')) set.add('italic')
+  if (node.closest('u')) set.add('underline')
+  if (node.closest('s')) set.add('strike')
+  if (node.closest('ol')) set.add('orderedList')
+  if (node.closest('ul')) set.add('unorderedList')
+  const block = node.closest('h1,h2,h3,h4,h5,h6,p,blockquote,pre') as HTMLElement
+  if (block) {
+    const tag = block.tagName.toLowerCase() as Command
+    if (tag) set.add(tag)
+    const align = block.style.textAlign
+    if (align === 'center') set.add('alignCenter')
+    else if (align === 'right') set.add('alignRight')
+    else if (align === 'justify') set.add('alignJustify')
+    else set.add('alignLeft')
+  }
+  return set
+}

--- a/ui-library/components/RichTextEditor/types.ts
+++ b/ui-library/components/RichTextEditor/types.ts
@@ -1,0 +1,10 @@
+import type { Command } from './commands'
+
+export type { Command }
+
+export interface RichTextEditorProps {
+  content?: string
+  placeholder?: string
+  readonly?: boolean
+  disabled?: boolean
+}

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -9,3 +9,4 @@ export { default as BaseSwitch } from './BaseSwitch/BaseSwitch.vue';
 export { default as BaseTab } from './BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';
 export { default as BaseTooltip } from './BaseTooltip/BaseTooltip.vue';
+export { default as RichTextEditor } from './RichTextEditor/RichTextEditor.vue';

--- a/ui-library/types/index.d.ts
+++ b/ui-library/types/index.d.ts
@@ -9,3 +9,4 @@ export { default as BaseSwitch } from '../components/BaseSwitch/BaseSwitch.vue';
 export { default as BaseTab } from '../components/BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from '../components/BaseTextarea/BaseTextarea.vue';
 export { default as BaseTooltip } from '../components/BaseTooltip/BaseTooltip.vue';
+export { default as RichTextEditor } from '../components/RichTextEditor/RichTextEditor.vue';


### PR DESCRIPTION
## Summary
- add RichTextEditor component with toolbar and formatting commands
- support v-model HTML content, placeholder, history, and theme-aware styling
- add Storybook demo with theme switcher and mobile viewport

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unexpected token in BaseCollapse.vue)*

------
https://chatgpt.com/codex/tasks/task_e_689459a279108321b05e67f8c92d25c5