### PR TITLE
feat: add BaseLabel component

### DIFF
--- a/ui-library/components/BaseLabel/BaseLabel.module.css
+++ b/ui-library/components/BaseLabel/BaseLabel.module.css
@@ -1,0 +1,51 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.left {
+  text-align: left;
+  align-items: flex-start;
+}
+
+.right {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.label {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.required {
+  color: var(--color-error);
+  margin-inline-start: var(--space-xs);
+}
+
+.hint {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
+}
+
+.error {
+  color: var(--color-error);
+}
+
+.disabled {
+  color: var(--color-disabled-text);
+}
+
+.sm {
+  font-size: var(--font-size-sm);
+}
+
+.md {
+  font-size: var(--font-size-md);
+}
+
+.lg {
+  font-size: var(--font-size-lg);
+}

--- a/ui-library/components/BaseLabel/BaseLabel.stories.ts
+++ b/ui-library/components/BaseLabel/BaseLabel.stories.ts
@@ -1,0 +1,60 @@
+import BaseLabel from './BaseLabel.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof BaseLabel> = {
+  title: 'Form/BaseLabel',
+  component: BaseLabel,
+  argTypes: {
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    align: { control: { type: 'select' }, options: ['left', 'right'] },
+    required: { control: 'boolean' },
+    error: { control: 'boolean' },
+    disabled: { control: 'boolean' }
+  },
+  args: {
+    for: 'field',
+    text: 'Label',
+    required: false,
+    error: false,
+    hint: '',
+    disabled: false,
+    size: 'md',
+    align: 'left'
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof BaseLabel>
+
+export const Default: Story = {}
+
+export const Required: Story = {
+  args: { required: true, text: 'Required field' }
+}
+
+export const Error: Story = {
+  args: { error: true, text: 'Error label' }
+}
+
+export const WithHint: Story = {
+  args: { hint: 'Helpful information', text: 'Label with hint' }
+}
+
+export const RightAligned: Story = {
+  args: { align: 'right', text: 'Right aligned' }
+}
+
+export const Sizes: Story = {
+  render: (args) => ({
+    components: { BaseLabel },
+    setup: () => ({ args }),
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem;">
+        <BaseLabel v-bind="args" size="sm" text="Small" for="small" />
+        <BaseLabel v-bind="args" size="md" text="Medium" for="medium" />
+        <BaseLabel v-bind="args" size="lg" text="Large" for="large" />
+      </div>
+    `
+  })
+}

--- a/ui-library/components/BaseLabel/BaseLabel.vue
+++ b/ui-library/components/BaseLabel/BaseLabel.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import styles from './BaseLabel.module.css'
+
+const props = withDefaults(
+  defineProps<{
+    for: string
+    text: string
+    required?: boolean
+    error?: boolean
+    hint?: string
+    disabled?: boolean
+    size?: 'sm' | 'md' | 'lg'
+    align?: 'left' | 'right'
+  }>(),
+  {
+    required: false,
+    error: false,
+    disabled: false,
+    size: 'md',
+    align: 'left'
+  }
+)
+
+const wrapperClasses = computed(() => [styles.wrapper, styles[props.align]])
+
+const labelClasses = computed(() => [
+  styles.label,
+  styles[props.size],
+  props.error && styles.error,
+  props.disabled && styles.disabled
+])
+
+const hintClasses = computed(() => [
+  styles.hint,
+  props.error && styles.error,
+  props.disabled && styles.disabled
+])
+
+const direction = computed(() => (props.align === 'right' ? 'rtl' : 'ltr'))
+const hintId = computed(() => (props.hint ? `${props.for}-hint` : undefined))
+</script>
+
+<template>
+  <div :class="wrapperClasses" :dir="direction">
+    <label :for="for" :class="labelClasses">
+      {{ text }}
+      <span v-if="required" :class="styles.required" aria-hidden="true">*</span>
+    </label>
+    <span v-if="hint" :id="hintId" :class="hintClasses">{{ hint }}</span>
+  </div>
+</template>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -3,6 +3,7 @@ export { default as BaseCheckbox } from './BaseCheckbox/BaseCheckbox.vue';
 export { default as BaseCollapse } from './BaseCollapse/BaseCollapse.vue';
 export { default as BaseDropdown } from './BaseDropdown/BaseDropdown.vue';
 export { default as BaseInput } from './BaseInput/BaseInput.vue';
+export { default as BaseLabel } from './BaseLabel/BaseLabel.vue';
 export { default as BaseModal } from './BaseModal/BaseModal.vue';
 export { default as BaseSelect } from './BaseSelect/BaseSelect.vue';
 export { default as BaseRadio } from './BaseRadio/BaseRadio.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseLabel component with support for error, hint, alignment and size
- style label via CSS variables and modules
- document component in Storybook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68946b941ba88321a327323047a8ea70