### PR TITLE
feat: add base form field wrapper

### DIFF
--- a/ui-library/components/BaseFormField/BaseFormField.module.css
+++ b/ui-library/components/BaseFormField/BaseFormField.module.css
@@ -1,0 +1,73 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+}
+
+.inline {
+  flex-direction: row;
+  align-items: center;
+}
+
+.label {
+  color: var(--color-text);
+  font-weight: var(--font-weight-medium);
+}
+
+.inline .label {
+  margin-right: var(--space-md);
+}
+
+.required {
+  color: var(--color-error);
+  margin-left: var(--space-xs);
+}
+
+.field {
+  flex: 1;
+}
+
+.hint {
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-xs);
+}
+
+.error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  margin-top: var(--space-xs);
+}
+
+.disabled {
+  opacity: 0.6;
+}
+
+.sm .label {
+  font-size: var(--font-size-sm);
+}
+
+.md .label {
+  font-size: var(--font-size-md);
+}
+
+.lg .label {
+  font-size: var(--font-size-lg);
+}
+
+.sm .control {
+  gap: var(--space-xs);
+}
+
+.md .control {
+  gap: var(--space-sm);
+}
+
+.lg .control {
+  gap: var(--space-md);
+}
+

--- a/ui-library/components/BaseFormField/BaseFormField.stories.ts
+++ b/ui-library/components/BaseFormField/BaseFormField.stories.ts
@@ -1,0 +1,89 @@
+import BaseFormField from './BaseFormField.vue'
+import BaseInput from '../BaseInput/BaseInput.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof BaseFormField> = {
+  title: 'Form/BaseFormField',
+  component: BaseFormField,
+  args: {
+    label: 'Label',
+    for: 'field',
+    size: 'md'
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof BaseFormField>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args">
+        <BaseInput id="field" />
+      </BaseFormField>
+    `
+  })
+}
+
+export const Required: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args" required>
+        <BaseInput id="field" />
+      </BaseFormField>
+    `
+  })
+}
+
+export const WithError: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args" error error-message="This field is required">
+        <BaseInput id="field" />
+      </BaseFormField>
+    `
+  })
+}
+
+export const WithHint: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args" hint="Enter your name">
+        <BaseInput id="field" />
+      </BaseFormField>
+    `
+  })
+}
+
+export const Inline: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args" inline>
+        <BaseInput id="field" />
+      </BaseFormField>
+    `
+  })
+}
+
+export const Disabled: Story = {
+  render: (args) => ({
+    components: { BaseFormField, BaseInput },
+    setup: () => ({ args }),
+    template: `
+      <BaseFormField v-bind="args" disabled>
+        <BaseInput id="field" disabled />
+      </BaseFormField>
+    `
+  })
+}

--- a/ui-library/components/BaseFormField/BaseFormField.vue
+++ b/ui-library/components/BaseFormField/BaseFormField.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import styles from './BaseFormField.module.css'
+
+withDefaults(
+  defineProps<{
+    label?: string
+    for?: string
+    hint?: string
+    error?: boolean
+    errorMessage?: string
+    required?: boolean
+    disabled?: boolean
+    inline?: boolean
+    size?: 'sm' | 'md' | 'lg'
+  }>(),
+  {
+    label: '',
+    for: '',
+    hint: '',
+    error: false,
+    errorMessage: '',
+    required: false,
+    disabled: false,
+    inline: false,
+    size: 'md'
+  }
+)
+</script>
+
+<template>
+  <div :class="[styles.wrapper, styles[size], disabled && styles.disabled]">
+    <div :class="[styles.control, inline && styles.inline]">
+      <label v-if="label" :for="for" :class="styles.label">
+        {{ label }}
+        <span v-if="required" :class="styles.required">*</span>
+      </label>
+      <div :class="styles.field">
+        <slot />
+      </div>
+    </div>
+    <div v-if="error && errorMessage" :class="styles.error">{{ errorMessage }}</div>
+    <div v-else-if="hint" :class="styles.hint">{{ hint }}</div>
+  </div>
+</template>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -11,3 +11,4 @@ export { default as BaseTab } from './BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';
 export { default as BaseTooltip } from './BaseTooltip/BaseTooltip.vue';
 export { default as RichTextEditor } from './RichTextEditor/RichTextEditor.vue';
+export { default as BaseFormField } from './BaseFormField/BaseFormField.vue';


### PR DESCRIPTION
## Summary
- add `BaseFormField` wrapper to compose labels, hints and errors
- showcase component states in Storybook

## Testing
- `npm test` *(fails: Missing script)*
- `npx vitest run` *(fails: Permission denied)*
- `npm run build` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68946c136188832186151992806c566e