### PR TITLE
feat: add useLoading composable

### DIFF
--- a/ui-library/composables/index.ts
+++ b/ui-library/composables/index.ts
@@ -1,0 +1,1 @@
+export { useLoading } from './useLoading';

--- a/ui-library/composables/useLoading.ts
+++ b/ui-library/composables/useLoading.ts
@@ -1,0 +1,55 @@
+import { ref, Ref } from 'vue';
+
+export function useLoading(
+  initial = false,
+  delay = 0,
+): {
+  loading: Ref<boolean>;
+  start: () => void;
+  stop: () => void;
+  withLoading: <T = void>(fn: () => Promise<T>) => Promise<T>;
+} {
+  const loading = ref(initial);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function start() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (delay > 0) {
+      timer = setTimeout(() => {
+        loading.value = true;
+        timer = null;
+      }, delay);
+    } else {
+      loading.value = true;
+    }
+  }
+
+  function stop() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    loading.value = false;
+  }
+
+  async function withLoading<T = void>(fn: () => Promise<T>): Promise<T> {
+    start();
+    try {
+      return await fn();
+    } finally {
+      stop();
+    }
+  }
+
+  return {
+    loading,
+    start,
+    stop,
+    withLoading,
+  };
+}
+
+export default useLoading;

--- a/ui-library/index.ts
+++ b/ui-library/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './composables';


### PR DESCRIPTION
## Summary
- add `useLoading` composable for reusable loading state management
- expose composables from package entry

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68946dbe0cf08321b6fbc8e6e8aad485