### PR TITLE
feat: add BaseBadge component

### DIFF
--- a/ui-library/components/BaseBadge/BaseBadge.module.css
+++ b/ui-library/components/BaseBadge/BaseBadge.module.css
@@ -1,0 +1,100 @@
+.badge {
+  --badge-color-value: var(--color-primary);
+  --badge-on-color-value: var(--color-on-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  line-height: 1;
+  padding: 0 var(--space-sm);
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  border: none;
+}
+
+.solid {
+  background-color: var(--badge-color-value);
+  color: var(--badge-on-color-value);
+}
+
+.soft {
+  background-color: color-mix(in srgb, var(--badge-color-value) 20%, transparent);
+  color: var(--badge-color-value);
+}
+
+.outline {
+  background-color: transparent;
+  color: var(--badge-color-value);
+  border: 1px solid var(--badge-color-value);
+}
+
+.sm {
+  padding: 0 var(--space-xs);
+  font-size: 0.75rem;
+}
+
+.md {
+  padding: 0 var(--space-sm);
+  font-size: 0.875rem;
+}
+
+.lg {
+  padding: 0 var(--space-md);
+  font-size: 1rem;
+}
+
+.rounded-sm {
+  border-radius: var(--radius-sm);
+}
+
+.rounded-md {
+  border-radius: var(--radius-md);
+}
+
+.rounded-full {
+  border-radius: var(--radius-full);
+}
+
+.dot {
+  padding: 0;
+  width: var(--space-sm);
+  height: var(--space-sm);
+  border-radius: var(--radius-full);
+}
+
+.positioned {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+}
+
+.primary {
+  --badge-color-value: var(--color-primary);
+  --badge-on-color-value: var(--color-on-primary);
+}
+
+.success {
+  --badge-color-value: var(--color-success);
+  --badge-on-color-value: var(--color-on-success);
+}
+
+.error {
+  --badge-color-value: var(--color-error);
+  --badge-on-color-value: var(--color-on-error);
+}
+
+.warning {
+  --badge-color-value: var(--color-warning);
+  --badge-on-color-value: var(--color-on-warning);
+}
+
+.info {
+  --badge-color-value: var(--color-info);
+  --badge-on-color-value: var(--color-on-info);
+}
+
+.neutral {
+  --badge-color-value: var(--color-muted);
+  --badge-on-color-value: var(--color-on-neutral, #fff);
+}

--- a/ui-library/components/BaseBadge/BaseBadge.stories.ts
+++ b/ui-library/components/BaseBadge/BaseBadge.stories.ts
@@ -1,0 +1,77 @@
+import BaseBadge from './BaseBadge.vue';
+import type { Meta, StoryFn } from '@storybook/vue3';
+
+export default {
+  title: 'Components/BaseBadge',
+  component: BaseBadge,
+  argTypes: {
+    color: { control: { type: 'select' }, options: ['primary','success','error','warning','info','neutral'] },
+    variant: { control: { type: 'select' }, options: ['solid','soft','outline'] },
+    size: { control: { type: 'select' }, options: ['sm','md','lg'] },
+    rounded: { control: { type: 'select' }, options: ['sm','md','full'] },
+    dot: { control: 'boolean' },
+    positioned: { control: 'boolean' },
+    text: { control: 'text' },
+  },
+} satisfies Meta<typeof BaseBadge>;
+
+const Template: StoryFn<typeof BaseBadge> = (args) => ({
+  components: { BaseBadge },
+  setup: () => ({ args }),
+  template: `<BaseBadge v-bind="args" />`,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  text: '9',
+  color: 'primary',
+  variant: 'solid',
+};
+
+export const Dot = Template.bind({});
+Dot.args = {
+  dot: true,
+  color: 'success',
+};
+
+export const Variants = () => ({
+  components: { BaseBadge },
+  template: `
+    <div style="display:flex; gap:0.5rem;">
+      <BaseBadge text="1" variant="solid" />
+      <BaseBadge text="2" variant="soft" />
+      <BaseBadge text="3" variant="outline" />
+    </div>
+  `,
+});
+
+export const Colors = () => ({
+  components: { BaseBadge },
+  data: () => ({ colors: ['primary','success','error','warning','info','neutral'] }),
+  template: `
+    <div style="display:flex; gap:0.5rem;">
+      <BaseBadge v-for="c in colors" :key="c" :color="c" text="1" />
+    </div>
+  `,
+});
+
+export const Sizes = () => ({
+  components: { BaseBadge },
+  template: `
+    <div style="display:flex; gap:0.5rem; align-items:center;">
+      <BaseBadge size="sm" text="S" />
+      <BaseBadge size="md" text="M" />
+      <BaseBadge size="lg" text="L" />
+    </div>
+  `,
+});
+
+export const PositionedOverIcon = () => ({
+  components: { BaseBadge },
+  template: `
+    <div style="position:relative; display:inline-block;">
+      <span style="font-size:2rem;">🔔</span>
+      <BaseBadge text="3" positioned />
+    </div>
+  `,
+});

--- a/ui-library/components/BaseBadge/BaseBadge.vue
+++ b/ui-library/components/BaseBadge/BaseBadge.vue
@@ -1,0 +1,42 @@
+<template>
+  <span
+    :class="[
+      $style.badge,
+      $style[color],
+      $style[variant],
+      $style[size],
+      $style[`rounded-${rounded}`],
+      {
+        [$style.dot]: dot,
+        [$style.positioned]: positioned,
+      },
+    ]"
+  >
+    <slot v-if="!dot">{{ text }}</slot>
+  </span>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    text?: string | number;
+    color?: 'primary' | 'success' | 'error' | 'warning' | 'info' | 'neutral';
+    variant?: 'solid' | 'soft' | 'outline';
+    size?: 'sm' | 'md' | 'lg';
+    rounded?: 'sm' | 'md' | 'full';
+    dot?: boolean;
+    positioned?: boolean;
+  }>(),
+  {
+    text: '',
+    color: 'primary',
+    variant: 'solid',
+    size: 'md',
+    rounded: 'md',
+    dot: false,
+    positioned: false,
+  }
+);
+</script>
+
+<style module src="./BaseBadge.module.css"></style>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -1,3 +1,4 @@
+export { default as BaseBadge } from './BaseBadge/BaseBadge.vue';
 export { default as BaseButton } from './BaseButton/BaseButton.vue';
 export { default as BaseCheckbox } from './BaseCheckbox/BaseCheckbox.vue';
 export { default as BaseCollapse } from './BaseCollapse/BaseCollapse.vue';


### PR DESCRIPTION
## Summary
- add reusable `<BaseBadge>` component with theme colors, variants, sizes, and positioning
- style badge via CSS modules and variables
- document component with Storybook examples

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")

------
https://chatgpt.com/codex/tasks/task_e_68946fa39848832188d3bec53d0292fc