### PR TITLE
feat: add BaseIcon component

### DIFF
--- a/ui-library/components/BaseIcon/BaseIcon.module.css
+++ b/ui-library/components/BaseIcon/BaseIcon.module.css
@@ -1,0 +1,16 @@
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--icon-color, currentColor);
+  width: var(--icon-size);
+  height: var(--icon-size);
+  --icon-size-sm: 1rem;
+  --icon-size-md: 1.5rem;
+  --icon-size-lg: 2rem;
+  --icon-size: var(--icon-size-md);
+}
+
+.sm { --icon-size: var(--icon-size-sm); }
+.md { --icon-size: var(--icon-size-md); }
+.lg { --icon-size: var(--icon-size-lg); }

--- a/ui-library/components/BaseIcon/BaseIcon.stories.ts
+++ b/ui-library/components/BaseIcon/BaseIcon.stories.ts
@@ -1,0 +1,58 @@
+import BaseIcon from './BaseIcon.vue';
+import type { Meta, StoryFn } from '@storybook/vue3';
+
+export default {
+  title: 'Components/BaseIcon',
+  component: BaseIcon,
+  argTypes: {
+    name: { control: 'text' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    color: { control: 'color' },
+    ariaLabel: { control: 'text' },
+  },
+} satisfies Meta<typeof BaseIcon>;
+
+const Template: StoryFn<typeof BaseIcon> = (args) => ({
+  components: { BaseIcon },
+  setup: () => ({ args }),
+  template: '<BaseIcon v-bind="args" />',
+});
+
+export const Named = Template.bind({});
+Named.args = {
+  name: 'check',
+  ariaLabel: 'Check icon',
+};
+
+export const CustomSvg = () => ({
+  components: { BaseIcon },
+  template: `
+    <BaseIcon aria-label="Custom svg">
+      <svg viewBox="0 0 24 24" fill="currentColor">
+        <circle cx="12" cy="12" r="10" />
+      </svg>
+    </BaseIcon>
+  `,
+});
+
+export const Sizes = () => ({
+  components: { BaseIcon },
+  template: `
+    <div style="display: flex; gap: 1rem; align-items: center;">
+      <BaseIcon name="check" size="sm" />
+      <BaseIcon name="check" size="md" />
+      <BaseIcon name="check" size="lg" />
+    </div>
+  `,
+});
+
+export const CustomColor = () => ({
+  components: { BaseIcon },
+  template: '<BaseIcon name="check" color="var(--color-primary)" />',
+});
+
+export const Accessible = Template.bind({});
+Accessible.args = {
+  name: 'close',
+  ariaLabel: 'Close icon',
+};

--- a/ui-library/components/BaseIcon/BaseIcon.vue
+++ b/ui-library/components/BaseIcon/BaseIcon.vue
@@ -1,0 +1,52 @@
+<template>
+  <span
+    v-if="iconSvg"
+    :class="[$style.icon, typeof size === 'string' ? $style[size] : null]"
+    :style="styleVars"
+    v-bind="a11yAttrs"
+    v-html="iconSvg"
+  />
+  <span
+    v-else
+    :class="[$style.icon, typeof size === 'string' ? $style[size] : null]"
+    :style="styleVars"
+    v-bind="a11yAttrs"
+  >
+    <slot />
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(defineProps<{
+  name?: string;
+  size?: 'sm' | 'md' | 'lg' | number;
+  color?: string;
+  ariaLabel?: string;
+}>(), {
+  size: 'md',
+  color: 'currentColor'
+});
+
+const icons = import.meta.glob('./icons/*.svg', { as: 'raw', eager: true }) as Record<string, string>;
+
+const iconSvg = computed(() => {
+  if (!props.name) return '';
+  const key = `./icons/${props.name}.svg`;
+  return icons[key] || '';
+});
+
+const styleVars = computed(() => ({
+  '--icon-color': props.color,
+  ...(typeof props.size === 'number' ? { '--icon-size': `${props.size}px` } : {}),
+}));
+
+const a11yAttrs = computed(() =>
+  props.ariaLabel
+    ? { role: 'img', 'aria-label': props.ariaLabel }
+    : { 'aria-hidden': 'true' }
+);
+</script>
+
+<style module src="./BaseIcon.module.css"></style>

--- a/ui-library/components/BaseIcon/icons/check.svg
+++ b/ui-library/components/BaseIcon/icons/check.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 13l4 4L19 7" />
+</svg>

--- a/ui-library/components/BaseIcon/icons/close.svg
+++ b/ui-library/components/BaseIcon/icons/close.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="18" y1="6" x2="6" y2="18" />
+  <line x1="6" y1="6" x2="18" y2="18" />
+</svg>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -13,3 +13,4 @@ export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';
 export { default as BaseTooltip } from './BaseTooltip/BaseTooltip.vue';
 export { default as RichTextEditor } from './RichTextEditor/RichTextEditor.vue';
 export { default as BaseFormField } from './BaseFormField/BaseFormField.vue';
+export { default as BaseIcon } from './BaseIcon/BaseIcon.vue';


### PR DESCRIPTION
## Summary
- add reusable BaseIcon component with named icon registry, slot fallback, theming, and a11y
- document BaseIcon usage in Storybook

## Testing
- `npm test` *(fails: Missing script "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68947023b528832191dfa75af674616f