### PR TITLE
feat: add base toggle button component

### DIFF
--- a/ui-library/components/BaseToggleButton/BaseToggleButton.module.css
+++ b/ui-library/components/BaseToggleButton/BaseToggleButton.module.css
@@ -1,0 +1,117 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  font-family: inherit;
+  font-weight: 500;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.sm {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.875rem;
+}
+
+.md {
+  padding: var(--space-sm) var(--space-md);
+  font-size: 1rem;
+}
+
+.lg {
+  padding: var(--space-md) var(--space-lg);
+  font-size: 1.125rem;
+}
+
+.on {}
+.off {}
+
+.solid.on,
+.outline.on {
+  background-color: var(--toggle-color);
+  border-color: var(--toggle-color);
+  color: var(--toggle-on-text);
+}
+
+.solid.off {
+  background-color: var(--color-surface);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.outline.off {
+  background-color: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.ghost.on {
+  background-color: transparent;
+  color: var(--toggle-color);
+  border-color: transparent;
+}
+
+.ghost.off {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--color-text);
+}
+
+.primary {
+  --toggle-color: var(--color-primary);
+  --toggle-on-text: var(--color-on-primary);
+}
+.success {
+  --toggle-color: var(--color-success);
+  --toggle-on-text: var(--color-on-success);
+}
+.error {
+  --toggle-color: var(--color-error);
+  --toggle-on-text: var(--color-on-error);
+}
+.info {
+  --toggle-color: var(--color-info);
+  --toggle-on-text: var(--color-on-info);
+}
+.warning {
+  --toggle-color: var(--color-warning);
+  --toggle-on-text: var(--color-on-warning);
+}
+
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading {
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.loader {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/ui-library/components/BaseToggleButton/BaseToggleButton.stories.ts
+++ b/ui-library/components/BaseToggleButton/BaseToggleButton.stories.ts
@@ -1,0 +1,85 @@
+import BaseToggleButton from './BaseToggleButton.vue'
+import type { Meta, StoryFn } from '@storybook/vue3'
+
+export default {
+  title: 'Components/BaseToggleButton',
+  component: BaseToggleButton,
+  argTypes: {
+    modelValue: { control: 'boolean' },
+    onLabel: { control: 'text' },
+    offLabel: { control: 'text' },
+    onIcon: { control: 'text' },
+    offIcon: { control: 'text' },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    size: { control: { type: 'select' }, options: ['sm', 'md', 'lg'] },
+    variant: { control: { type: 'select' }, options: ['solid', 'outline', 'ghost'] },
+    color: {
+      control: { type: 'select' },
+      options: ['primary', 'success', 'error', 'info', 'warning']
+    }
+  }
+} satisfies Meta<typeof BaseToggleButton>
+
+const Template: StoryFn<typeof BaseToggleButton> = (args) => ({
+  components: { BaseToggleButton },
+  setup: () => ({ args }),
+  template: '<BaseToggleButton v-model="args.modelValue" v-bind="args" />'
+})
+
+export const Default = Template.bind({})
+Default.args = {
+  modelValue: false,
+  onLabel: 'On',
+  offLabel: 'Off'
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+  disabled: true
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  loading: true
+}
+
+export const Variants = () => ({
+  components: { BaseToggleButton },
+  template: `
+    <div style="display: flex; gap: 1rem;">
+      <BaseToggleButton variant="solid" />
+      <BaseToggleButton variant="outline" />
+      <BaseToggleButton variant="ghost" />
+    </div>
+  `
+})
+
+export const Sizes = () => ({
+  components: { BaseToggleButton },
+  template: `
+    <div style="display: flex; gap: 1rem;">
+      <BaseToggleButton size="sm" />
+      <BaseToggleButton size="md" />
+      <BaseToggleButton size="lg" />
+    </div>
+  `
+})
+
+export const WithCustomSlots = () => ({
+  components: { BaseToggleButton },
+  template: `
+    <BaseToggleButton>
+      <template #on>
+        <span style="display: flex; align-items: center; gap: 0.25rem;">
+          <i class="pi pi-check"></i> Active
+        </span>
+      </template>
+      <template #off>
+        <span style="display: flex; align-items: center; gap: 0.25rem;">
+          <i class="pi pi-times"></i> Inactive
+        </span>
+      </template>
+    </BaseToggleButton>
+  `
+})

--- a/ui-library/components/BaseToggleButton/BaseToggleButton.vue
+++ b/ui-library/components/BaseToggleButton/BaseToggleButton.vue
@@ -1,0 +1,76 @@
+<template>
+  <button
+    :class="[
+      styles.button,
+      styles[variant],
+      styles[size],
+      styles[modelValue ? 'on' : 'off'],
+      modelValue ? styles[color] : '',
+      {
+        [styles.disabled]: disabled,
+        [styles.loading]: loading
+      }
+    ]"
+    type="button"
+    :aria-pressed="modelValue"
+    :disabled="disabled || loading"
+    @click="toggle"
+    @keydown.enter.prevent="toggle"
+    @keydown.space.prevent="toggle"
+  >
+    <span v-if="loading" :class="styles.loader"></span>
+    <template v-else>
+      <slot v-if="modelValue" name="on">
+        <i v-if="onIcon" :class="[styles.icon, onIcon]" />
+        <span>{{ onLabel }}</span>
+      </slot>
+      <slot v-else name="off">
+        <i v-if="offIcon" :class="[styles.icon, offIcon]" />
+        <span>{{ offLabel }}</span>
+      </slot>
+    </template>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { useAttrs } from 'vue'
+import styles from './BaseToggleButton.module.css'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    onLabel?: string
+    offLabel?: string
+    onIcon?: string
+    offIcon?: string
+    disabled?: boolean
+    loading?: boolean
+    size?: 'sm' | 'md' | 'lg'
+    variant?: 'solid' | 'outline' | 'ghost'
+    color?: 'primary' | 'success' | 'error' | 'info' | 'warning'
+  }>(),
+  {
+    modelValue: false,
+    onLabel: 'On',
+    offLabel: 'Off',
+    disabled: false,
+    loading: false,
+    size: 'md',
+    variant: 'solid',
+    color: 'primary'
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+useAttrs()
+
+function toggle() {
+  if (props.disabled || props.loading) return
+  emit('update:modelValue', !props.modelValue)
+}
+</script>
+
+<style module src="./BaseToggleButton.module.css"></style>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -10,6 +10,7 @@ export { default as BaseRadio } from './BaseRadio/BaseRadio.vue';
 export { default as BaseSwitch } from './BaseSwitch/BaseSwitch.vue';
 export { default as BaseTab } from './BaseTab/BaseTab.vue';
 export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';
+export { default as BaseToggleButton } from './BaseToggleButton/BaseToggleButton.vue';
 export { default as BaseTooltip } from './BaseTooltip/BaseTooltip.vue';
 export { default as RichTextEditor } from './RichTextEditor/RichTextEditor.vue';
 export { default as BaseFormField } from './BaseFormField/BaseFormField.vue';


### PR DESCRIPTION
## Summary
- add reusable `BaseToggleButton` component with size, variant, color, loading and disabled support
- document component with Storybook examples
- export `BaseToggleButton` from components index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_689471e0728c8321b05dd9baf3617eb2