### PR TITLE
feat: add BaseSplitButton component

### DIFF
--- a/ui-library/components/BaseSplitButton/BaseSplitButton.module.css
+++ b/ui-library/components/BaseSplitButton/BaseSplitButton.module.css
@@ -1,0 +1,70 @@
+.splitButton {
+  display: inline-flex;
+  position: relative;
+}
+
+.main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.toggle {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding-inline: var(--space-sm);
+}
+
+.caret {
+  font-size: 0.75em;
+}
+
+.icon {
+  margin-inline-end: var(--space-sm);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + var(--space-xs));
+  right: 0;
+  min-width: 100%;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-xs) 0;
+  z-index: 10;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+}
+
+.menuItem:hover,
+.focused {
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.itemIcon {
+  font-size: var(--font-size-sm);
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}

--- a/ui-library/components/BaseSplitButton/BaseSplitButton.stories.ts
+++ b/ui-library/components/BaseSplitButton/BaseSplitButton.stories.ts
@@ -1,0 +1,62 @@
+import BaseSplitButton from './BaseSplitButton.vue';
+import type { Meta, StoryFn } from '@storybook/vue3';
+
+export default {
+  title: 'Components/BaseSplitButton',
+  component: BaseSplitButton,
+  args: {
+    label: 'Save',
+    model: [
+      { label: 'Update', command: () => console.log('update') },
+      { label: 'Delete', command: () => console.log('delete') }
+    ],
+    color: 'primary',
+    size: 'md',
+    disabled: false,
+    loading: false,
+  },
+  argTypes: {
+    color: {
+      control: { type: 'select' },
+      options: ['primary','secondary','success','error','warning','info','outline','ghost']
+    },
+    size: { control: { type: 'select' }, options: ['sm','md','lg'] },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+  },
+} satisfies Meta<typeof BaseSplitButton>;
+
+const Template: StoryFn<typeof BaseSplitButton> = (args) => ({
+  components: { BaseSplitButton },
+  setup: () => ({ args }),
+  template: `<BaseSplitButton v-bind="args" @click="() => console.log('main')" />`,
+});
+
+export const Default = Template.bind({});
+
+export const CustomItems: StoryFn<typeof BaseSplitButton> = (args) => ({
+  components: { BaseSplitButton },
+  setup: () => ({ args }),
+  template: `
+    <BaseSplitButton v-bind="args">
+      <template #item="{ item }">
+        <div style="display:flex;align-items:center;gap:0.5rem;">
+          <i v-if="item.icon" :class="item.icon"></i>
+          <span>{{ item.label }}</span>
+        </div>
+      </template>
+    </BaseSplitButton>
+  `,
+});
+CustomItems.args = {
+  model: [
+    { label: 'Refresh', icon: 'fa fa-refresh', command: () => console.log('refresh') },
+    { label: 'Settings', icon: 'fa fa-cog', command: () => console.log('settings') },
+  ],
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true };
+
+export const Loading = Template.bind({});
+Loading.args = { loading: true };

--- a/ui-library/components/BaseSplitButton/BaseSplitButton.vue
+++ b/ui-library/components/BaseSplitButton/BaseSplitButton.vue
@@ -1,0 +1,191 @@
+<template>
+  <div :class="$style.splitButton" ref="root" @keydown="onKeydown">
+    <slot
+      name="button"
+      :onClick="onMainClick"
+      :disabled="disabled"
+      :loading="loading"
+    >
+      <BaseButton
+        :variant="color"
+        :size="size"
+        :disabled="disabled"
+        :loading="loading"
+        :class="$style.main"
+        @click="onMainClick"
+      >
+        <i v-if="icon" :class="[$style.icon, icon]"></i>
+        {{ label }}
+      </BaseButton>
+    </slot>
+    <BaseButton
+      ref="toggleBtn"
+      :variant="color"
+      :size="size"
+      :disabled="disabled"
+      :class="$style.toggle"
+      icon
+      @click="toggle"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+    >
+      <span :class="$style.caret">▼</span>
+    </BaseButton>
+    <transition name="fade">
+      <ul v-show="isOpen" ref="menu" :class="$style.menu">
+        <li
+          v-for="(item, index) in model"
+          :key="index"
+          :ref="el => setItemRef(el, index)"
+          :class="[$style.menuItem, focusedIndex === index && $style.focused, item.disabled && $style.disabled]"
+          @click="() => onItemSelect(item)"
+          @mouseenter="focus(index)"
+          tabindex="-1"
+        >
+          <slot name="item" :item="item">
+            <i v-if="item.icon" :class="[$style.itemIcon, item.icon]"></i>
+            <span>{{ item.label }}</span>
+          </slot>
+        </li>
+      </ul>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, withDefaults, defineProps, defineEmits, onMounted, onBeforeUnmount, nextTick, watchEffect } from 'vue';
+import BaseButton from '../BaseButton/BaseButton.vue';
+
+interface MenuItem {
+  label: string;
+  icon?: string;
+  disabled?: boolean;
+  command?: () => void;
+}
+
+const props = withDefaults(defineProps<{
+  label: string;
+  icon?: string;
+  model?: MenuItem[];
+  disabled?: boolean;
+  loading?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  color?: 'primary' | 'secondary' | 'success' | 'error' | 'warning' | 'info' | 'outline' | 'ghost';
+}>(), {
+  model: () => [],
+  disabled: false,
+  loading: false,
+  size: 'md',
+  color: 'primary'
+});
+
+const emit = defineEmits<{
+  (e: 'click', ev: MouseEvent): void;
+}>();
+
+const isOpen = ref(false);
+const root = ref<HTMLElement | null>(null);
+const toggleBtn = ref<HTMLElement | null>(null);
+const menu = ref<HTMLElement | null>(null);
+const focusedIndex = ref(-1);
+const itemRefs = ref<HTMLElement[]>([]);
+
+function onMainClick(e: MouseEvent) {
+  if (props.disabled || props.loading) return;
+  emit('click', e);
+}
+
+function toggle() {
+  if (props.disabled || props.loading) return;
+  isOpen.value = !isOpen.value;
+}
+
+function close() {
+  isOpen.value = false;
+  focusedIndex.value = -1;
+}
+
+function onItemSelect(item: MenuItem) {
+  if (item.disabled) return;
+  item.command?.();
+  close();
+}
+
+function setItemRef(el: HTMLElement | null, index: number) {
+  if (el) itemRefs.value[index] = el;
+}
+
+function focus(index: number) {
+  if (props.model[index]?.disabled) return;
+  focusedIndex.value = index;
+  itemRefs.value[index]?.focus();
+}
+
+function focusNext() {
+  if (!props.model.length) return;
+  let i = focusedIndex.value;
+  do {
+    i = (i + 1) % props.model.length;
+  } while (props.model[i]?.disabled && i !== focusedIndex.value);
+  focus(i);
+}
+
+function focusPrev() {
+  if (!props.model.length) return;
+  let i = focusedIndex.value;
+  do {
+    i = (i - 1 + props.model.length) % props.model.length;
+  } while (props.model[i]?.disabled && i !== focusedIndex.value);
+  focus(i);
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (!isOpen.value) return;
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault();
+      focusNext();
+      break;
+    case 'ArrowUp':
+      e.preventDefault();
+      focusPrev();
+      break;
+    case 'Enter':
+      e.preventDefault();
+      if (focusedIndex.value >= 0) {
+        const item = props.model[focusedIndex.value];
+        if (item) onItemSelect(item);
+      }
+      break;
+    case 'Escape':
+      e.preventDefault();
+      close();
+      toggleBtn.value?.focus();
+      break;
+  }
+}
+
+function handleClickOutside(e: MouseEvent) {
+  if (root.value && !root.value.contains(e.target as Node)) {
+    close();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
+
+watchEffect(() => {
+  if (isOpen.value) {
+    nextTick(() => {
+      focusNext();
+    });
+  }
+});
+</script>
+
+<style module src="./BaseSplitButton.module.css"></style>

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -13,3 +13,4 @@ export { default as BaseTextarea } from './BaseTextarea/BaseTextarea.vue';
 export { default as BaseTooltip } from './BaseTooltip/BaseTooltip.vue';
 export { default as RichTextEditor } from './RichTextEditor/RichTextEditor.vue';
 export { default as BaseFormField } from './BaseFormField/BaseFormField.vue';
+export { default as BaseSplitButton } from './BaseSplitButton/BaseSplitButton.vue';


### PR DESCRIPTION
## Summary
- add BaseSplitButton with menu actions and keyboard support
- style split button via CSS variables
- document usage through Storybook examples

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68947739fce08321abf281f9caf4422b