### PR TITLE
feat: add base data table component

### DIFF
--- a/ui-library/components/BaseDataTable/BaseDataTable.module.css
+++ b/ui-library/components/BaseDataTable/BaseDataTable.module.css
@@ -1,0 +1,62 @@
+/* BaseDataTable.module.css - CSS Module with CSS variables */
+
+.root {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.header {
+  background: var(--table-header-bg);
+}
+
+.row {
+  background: var(--table-row-bg);
+  transition: background var(--transition-fast);
+}
+
+.row:hover {
+  background: var(--table-row-hover-bg);
+}
+
+.cell {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.selected {
+  background: var(--table-row-selected-bg);
+}
+
+.sortable {
+  cursor: pointer;
+}
+
+.loading,
+.empty {
+  text-align: center;
+  padding: var(--spacing-md);
+}
+
+.boolean {
+  color: var(--color-primary);
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+}
+
+.pagination button {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: var(--radius);
+}

--- a/ui-library/components/BaseDataTable/BaseDataTable.stories.ts
+++ b/ui-library/components/BaseDataTable/BaseDataTable.stories.ts
@@ -1,0 +1,98 @@
+// BaseDataTable.stories.ts - Storybook stories for BaseDataTable
+import BaseDataTable from './BaseDataTable.vue';
+import type { Meta, StoryFn } from '@storybook/vue3';
+import type { Column, Pagination } from './types';
+
+export default {
+  title: 'Components/BaseDataTable',
+  component: BaseDataTable,
+  argTypes: {
+    selectionMode: {
+      control: { type: 'select' },
+      options: ['single', 'multiple', null],
+    },
+  },
+} as Meta<typeof BaseDataTable>;
+
+const defaultColumns: Column[] = [
+  { field: 'name', header: 'Name', sortable: true, filterable: true },
+  { field: 'amount', header: 'Amount', type: 'number', sortable: true },
+  { field: 'price', header: 'Price', type: 'currency', sortable: true, formatOptions: { currency: 'USD' } },
+  { field: 'date', header: 'Date', type: 'date', sortable: true },
+  { field: 'active', header: 'Active', type: 'boolean', sortable: true },
+];
+
+const defaultData = [
+  { name: 'Alpha', amount: 1234, price: 19.99, date: '2023-09-01', active: true },
+  { name: 'Beta', amount: 5678, price: 9.5, date: '2023-09-05', active: false },
+];
+
+const defaultPagination: Pagination = { page: 1, pageSize: 5, total: defaultData.length };
+
+export const Basic: StoryFn<typeof BaseDataTable> = args => ({
+  components: { BaseDataTable },
+  setup() {
+    return { args };
+  },
+  template: '<BaseDataTable v-bind="args" />',
+});
+
+Basic.args = {
+  columns: defaultColumns,
+  data: defaultData,
+  pagination: defaultPagination,
+  loading: false,
+  selectionMode: null,
+};
+
+export const ColumnTypes: StoryFn<typeof BaseDataTable> = args => ({
+  components: { BaseDataTable },
+  setup() {
+    return { args };
+  },
+  template: `
+    <BaseDataTable v-bind="args">
+      <template #custom="{ row }">
+        <strong>{{ row.name }}</strong>
+      </template>
+    </BaseDataTable>
+  `,
+});
+
+ColumnTypes.args = {
+  columns: [
+    { field: 'text', header: 'Text' },
+    { field: 'num', header: 'Number', type: 'number' },
+    { field: 'curr', header: 'Currency', type: 'currency', formatOptions: { currency: 'USD' } },
+    { field: 'date', header: 'Date', type: 'date' },
+    { field: 'dateFa', header: 'Date FA', type: 'date-fa' },
+    { field: 'bool', header: 'Boolean', type: 'boolean' },
+    { field: 'file', header: 'File', type: 'file' },
+    { field: 'slot', header: 'Slot', type: 'slot', slotName: 'custom' },
+  ] as Column[],
+  data: [
+    {
+      text: 'Row1',
+      num: 1000,
+      curr: 2000,
+      date: '2023-09-01',
+      dateFa: '2023-09-01',
+      bool: true,
+      file: '#',
+      name: 'Custom1',
+    },
+    {
+      text: 'Row2',
+      num: 2000,
+      curr: 3000,
+      date: '2023-09-02',
+      dateFa: '2023-09-02',
+      bool: false,
+      file: '#',
+      name: 'Custom2',
+    },
+  ],
+  pagination: { page: 1, pageSize: 10, total: 2 },
+  selectionMode: null,
+  loading: false,
+};

--- a/ui-library/components/BaseDataTable/BaseDataTable.vue
+++ b/ui-library/components/BaseDataTable/BaseDataTable.vue
@@ -1,0 +1,152 @@
+<!-- BaseDataTable.vue - Reusable data table component -->
+<template>
+  <div :class="styles.root">
+    <table :class="styles.table">
+      <thead>
+        <TableHeader :columns="columns" :sort-state="sortState" @sort="onSort" />
+        <TableFilters v-if="hasFilters" :columns="columns" :model="filters" @filter="onFilter" />
+      </thead>
+      <TableBody
+        :columns="columns"
+        :rows="paginatedData"
+        :loading="loading"
+        :empty="!loading && paginatedData.length === 0"
+        :selection-mode="selectionMode"
+        :model-value="selection"
+        @update:modelValue="onSelection"
+      />
+    </table>
+    <TableFooter
+      v-if="paginationState"
+      :pagination="paginationState"
+      @update:pagination="onPagination"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import styles from './BaseDataTable.module.css';
+import type {
+  Column,
+  Pagination,
+  SelectionMode,
+  SortState,
+  FilterModel,
+} from './types';
+import TableHeader from './components/TableHeader.vue';
+import TableBody from './components/TableBody.vue';
+import TableFooter from './components/TableFooter.vue';
+import TableFilters from './components/TableFilters.vue';
+
+const props = defineProps<{
+  columns: Column[];
+  data: any[];
+  pagination?: Pagination;
+  selectionMode?: SelectionMode;
+  modelValue?: any[];
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: any[]): void;
+  (e: 'update:pagination', value: Pagination): void;
+  (e: 'sort', value: SortState): void;
+  (e: 'filter', value: FilterModel): void;
+}>();
+
+const sortState = ref<SortState | null>(null);
+const filters = ref<FilterModel>({});
+
+const selection = ref<any[]>(props.modelValue ?? []);
+watch(
+  () => props.modelValue,
+  v => {
+    selection.value = v ?? [];
+  }
+);
+
+const paginationState = ref<Pagination | undefined>(
+  props.pagination ? { ...props.pagination } : undefined
+);
+watch(
+  () => props.pagination,
+  v => {
+    paginationState.value = v ? { ...v } : undefined;
+  },
+  { deep: true }
+);
+
+const filteredData = computed(() => {
+  if (!Object.keys(filters.value).length) return props.data;
+  return props.data.filter(row => {
+    return Object.entries(filters.value).every(([field, value]) => {
+      if (value == null || value === '') return true;
+      const cell = row[field as keyof typeof row];
+      return String(cell ?? '')
+        .toLowerCase()
+        .includes(String(value).toLowerCase());
+    });
+  });
+});
+
+const sortedData = computed(() => {
+  if (!sortState.value) return filteredData.value;
+  const { field, order } = sortState.value;
+  return [...filteredData.value].sort((a, b) => {
+    const av = a[field];
+    const bv = b[field];
+    if (av == null) return -1;
+    if (bv == null) return 1;
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return order === 'asc' ? av - bv : bv - av;
+    }
+    return order === 'asc'
+      ? String(av).localeCompare(String(bv))
+      : String(bv).localeCompare(String(av));
+  });
+});
+
+const paginatedData = computed(() => {
+  if (!paginationState.value) return sortedData.value;
+  const start = (paginationState.value.page - 1) * paginationState.value.pageSize;
+  const end = start + paginationState.value.pageSize;
+  return sortedData.value.slice(start, end);
+});
+
+watch(
+  sortedData,
+  val => {
+    if (paginationState.value) {
+      paginationState.value.total = val.length;
+    }
+  },
+  { immediate: true }
+);
+
+const hasFilters = computed(() => props.columns.some(c => c.filterable));
+
+function onSort(field: string) {
+  if (sortState.value && sortState.value.field === field) {
+    sortState.value.order = sortState.value.order === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortState.value = { field, order: 'asc' };
+  }
+  emit('sort', sortState.value);
+}
+
+function onFilter(model: FilterModel) {
+  filters.value = model;
+  emit('filter', model);
+}
+
+function onPagination(pag: Pagination) {
+  paginationState.value = pag;
+  emit('update:pagination', pag);
+}
+
+function onSelection(val: any[]) {
+  selection.value = val;
+  emit('update:modelValue', val);
+}
+</script>

--- a/ui-library/components/BaseDataTable/components/TableBody.vue
+++ b/ui-library/components/BaseDataTable/components/TableBody.vue
@@ -1,0 +1,105 @@
+<!-- TableBody.vue - Renders table body rows and handles selection -->
+<template>
+  <tbody>
+    <tr v-if="loading" :class="styles.loading">
+      <td :colspan="columns.length">Loading...</td>
+    </tr>
+    <tr v-else-if="empty" :class="styles.empty">
+      <td :colspan="columns.length">No records found</td>
+    </tr>
+    <tr
+      v-else
+      v-for="(row, rowIndex) in rows"
+      :key="rowIndex"
+      :class="[styles.row, { [styles.selected]: isSelected(row) }]"
+      @click="toggle(row)"
+    >
+      <td
+        v-for="col in columns"
+        :key="col.field"
+        :class="styles.cell"
+        :style="{ textAlign: defaultAlign(col) }"
+      >
+        <template v-if="col.type === 'number'">
+          {{ formatNumber(row[col.field], undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'currency'">
+          {{ formatCurrency(row[col.field], col.formatOptions?.currency, undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'date'">
+          {{ formatDate(row[col.field], undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'date-fa'">
+          {{ formatDateFa(row[col.field], col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'boolean'">
+          <span :class="styles.boolean">{{ formatBoolean(row[col.field]) }}</span>
+        </template>
+        <template v-else-if="col.type === 'file'">
+          <a v-if="row[col.field]" :href="row[col.field]" download target="_blank">📄</a>
+        </template>
+        <template
+          v-else-if="col.type === 'slot' && col.slotName && slots[col.slotName]"
+        >
+          <component :is="slots[col.slotName]" :row="row" />
+        </template>
+        <template v-else>
+          {{ row[col.field] }}
+        </template>
+      </td>
+    </tr>
+  </tbody>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, useSlots } from 'vue';
+import styles from '../BaseDataTable.module.css';
+import type { Column, SelectionMode } from '../types';
+import { formatNumber, formatCurrency, formatDate, formatDateFa, formatBoolean } from '../utils/formatters';
+
+const props = defineProps<{
+  columns: Column[];
+  rows: any[];
+  selectionMode?: SelectionMode;
+  modelValue: any[];
+  loading?: boolean;
+  empty?: boolean;
+}>();
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: any[]): void }>();
+const slots = useSlots();
+
+const selected = ref<any[]>(props.modelValue ?? []);
+
+watch(
+  () => props.modelValue,
+  v => {
+    selected.value = v ?? [];
+  }
+);
+
+function isSelected(row: any): boolean {
+  return selected.value.includes(row);
+}
+
+function toggle(row: any) {
+  if (!props.selectionMode) return;
+  let next: any[] = [];
+  if (props.selectionMode === 'single') {
+    next = isSelected(row) ? [] : [row];
+  } else {
+    next = isSelected(row)
+      ? selected.value.filter(r => r !== row)
+      : [...selected.value, row];
+  }
+  selected.value = next;
+  emit('update:modelValue', next);
+}
+
+function defaultAlign(col: Column): 'left' | 'right' | 'center' {
+  if (col.align) return col.align;
+  if (col.type === 'number' || col.type === 'currency') return 'right';
+  if (col.type === 'boolean') return 'center';
+  return 'left';
+}
+</script>

--- a/ui-library/components/BaseDataTable/components/TableFilters.vue
+++ b/ui-library/components/BaseDataTable/components/TableFilters.vue
@@ -1,0 +1,34 @@
+<!-- TableFilters.vue - Renders filter inputs for filterable columns -->
+<template>
+  <tr>
+    <th v-for="col in columns" :key="col.field">
+      <input
+        v-if="col.filterable"
+        type="text"
+        v-model="local[col.field]"
+        @input="emitFilter"
+      />
+    </th>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import type { Column, FilterModel } from '../types';
+
+const props = defineProps<{ columns: Column[]; model: FilterModel }>();
+const emit = defineEmits<{ (e: 'filter', model: FilterModel): void }>();
+
+const local = ref<Record<string, string>>({ ...props.model });
+
+watch(
+  () => props.model,
+  v => {
+    local.value = { ...v };
+  }
+);
+
+function emitFilter() {
+  emit('filter', { ...local.value });
+}
+</script>

--- a/ui-library/components/BaseDataTable/components/TableFooter.vue
+++ b/ui-library/components/BaseDataTable/components/TableFooter.vue
@@ -1,0 +1,18 @@
+<!-- TableFooter.vue - Container for pagination or other footer elements -->
+<template>
+  <div>
+    <TablePagination :pagination="pagination" @update:pagination="update" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import TablePagination from './TablePagination.vue';
+import type { Pagination } from '../types';
+
+const props = defineProps<{ pagination: Pagination }>();
+const emit = defineEmits<{ (e: 'update:pagination', value: Pagination): void }>();
+
+function update(value: Pagination) {
+  emit('update:pagination', value);
+}
+</script>

--- a/ui-library/components/BaseDataTable/components/TableHeader.vue
+++ b/ui-library/components/BaseDataTable/components/TableHeader.vue
@@ -1,0 +1,32 @@
+<!-- TableHeader.vue - Renders table header cells and handles sorting -->
+<template>
+  <tr :class="styles.header">
+    <th
+      v-for="col in columns"
+      :key="col.field"
+      :style="{ width: col.width, textAlign: col.align || 'left' }"
+      :class="{ [styles.sortable]: col.sortable }"
+      @click="emitSort(col)"
+    >
+      <span>{{ col.header }}</span>
+      <span v-if="col.sortable">
+        <span v-if="sortState && sortState.field === col.field">
+          {{ sortState.order === 'asc' ? '▲' : '▼' }}
+        </span>
+        <span v-else>↕</span>
+      </span>
+    </th>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import styles from '../BaseDataTable.module.css';
+import type { Column, SortState } from '../types';
+
+const props = defineProps<{ columns: Column[]; sortState: SortState | null }>();
+const emit = defineEmits<{ (e: 'sort', field: string): void }>();
+
+function emitSort(col: Column) {
+  if (col.sortable) emit('sort', col.field);
+}
+</script>

--- a/ui-library/components/BaseDataTable/components/TablePagination.vue
+++ b/ui-library/components/BaseDataTable/components/TablePagination.vue
@@ -1,0 +1,31 @@
+<!-- TablePagination.vue - Basic pagination controls -->
+<template>
+  <div :class="styles.pagination">
+    <button type="button" @click="prev" :disabled="pagination.page <= 1">◀</button>
+    <span>{{ pagination.page }} / {{ pageCount }}</span>
+    <button type="button" @click="next" :disabled="pagination.page >= pageCount">▶</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import styles from '../BaseDataTable.module.css';
+import type { Pagination } from '../types';
+
+const props = defineProps<{ pagination: Pagination }>();
+const emit = defineEmits<{ (e: 'update:pagination', value: Pagination): void }>();
+
+const pageCount = computed(() => Math.max(1, Math.ceil(props.pagination.total / props.pagination.pageSize)));
+
+function prev() {
+  if (props.pagination.page > 1) {
+    emit('update:pagination', { ...props.pagination, page: props.pagination.page - 1 });
+  }
+}
+
+function next() {
+  if (props.pagination.page < pageCount.value) {
+    emit('update:pagination', { ...props.pagination, page: props.pagination.page + 1 });
+  }
+}
+</script>

--- a/ui-library/components/BaseDataTable/types.ts
+++ b/ui-library/components/BaseDataTable/types.ts
@@ -1,0 +1,28 @@
+// types.ts - Interfaces for BaseDataTable component
+
+export interface Column {
+  field: string;
+  header: string;
+  type?: 'text' | 'number' | 'currency' | 'date-fa' | 'date' | 'boolean' | 'file' | 'slot';
+  sortable?: boolean;
+  filterable?: boolean;
+  width?: string;
+  align?: 'left' | 'center' | 'right';
+  slotName?: string;
+  formatOptions?: Record<string, any>;
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export type SelectionMode = 'single' | 'multiple' | null;
+
+export interface SortState {
+  field: string;
+  order: 'asc' | 'desc';
+}
+
+export type FilterModel = Record<string, any>;

--- a/ui-library/components/BaseDataTable/utils/formatters.ts
+++ b/ui-library/components/BaseDataTable/utils/formatters.ts
@@ -1,0 +1,30 @@
+// formatters.ts - Helper formatting functions for BaseDataTable
+
+export function formatNumber(value: number, locale = 'fa-IR', options?: Intl.NumberFormatOptions): string {
+  return new Intl.NumberFormat(locale, options).format(value);
+}
+
+export function formatCurrency(
+  value: number,
+  currency: string = 'IRR',
+  locale = 'fa-IR',
+  options?: Intl.NumberFormatOptions
+): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency, ...options }).format(value);
+}
+
+export function formatDate(
+  value: string | number | Date,
+  locale = 'en-US',
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(new Date(value));
+}
+
+export function formatDateFa(value: string | number | Date, options?: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('fa-IR-u-ca-persian', options).format(new Date(value));
+}
+
+export function formatBoolean(value: boolean): string {
+  return value ? '✔︎' : '✘';
+}

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -19,3 +19,4 @@ export { default as BaseSplitButton } from './BaseSplitButton/BaseSplitButton.vu
 export { default as BaseSpeedDial } from './BaseSpeedDial/BaseSpeedDial.vue';
 export { default as BaseImage } from './BaseImage/BaseImage.vue';
 export { default as BaseIcon } from './BaseIcon/BaseIcon.vue';
+export { default as BaseDataTable } from './BaseDataTable/BaseDataTable.vue';


### PR DESCRIPTION
## Summary
- add BaseDataTable Vue 3 component with sorting, filtering, pagination and selection
- include reusable subcomponents and format utilities
- provide storybook examples and library export

## Testing
- `npm run build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_6896610ea9088321aa873bc767f4009b