### PR TITLE
feat: add advanced data table component

### DIFF
--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.module.css
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.module.css
@@ -1,0 +1,81 @@
+/* AdvancedDataTable.module.css - CSS Module with CSS variables */
+
+.root {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.header {
+  background: var(--table-header-bg);
+}
+
+.row {
+  background: var(--table-row-bg);
+  transition: background var(--transition-fast);
+}
+
+.row:hover,
+.row:focus-visible {
+  background: var(--table-row-hover-bg);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--color-primary);
+}
+
+.row:active {
+  background: var(--table-row-active-bg, var(--table-row-hover-bg));
+}
+
+.cell {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.selected {
+  background: var(--table-row-selected-bg);
+}
+
+.sortable {
+  cursor: pointer;
+}
+
+.sortable:hover,
+.sortable:focus-visible {
+  background: var(--table-header-hover-bg);
+  outline: 2px solid var(--color-primary);
+}
+
+.sortable:active {
+  background: var(--table-header-active-bg, var(--table-header-hover-bg));
+}
+
+.loading,
+.empty {
+  text-align: center;
+  padding: var(--spacing-md);
+}
+
+.boolean {
+  color: var(--color-primary);
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+}
+
+.pagination button {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: var(--radius);
+}

--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
@@ -1,0 +1,138 @@
+// AdvancedDataTable.stories.ts - Storybook stories for AdvancedDataTable
+import AdvancedDataTable from './AdvancedDataTable.vue';
+import type { Meta, StoryFn } from '@storybook/vue3';
+import type { Column, Pagination } from './types';
+
+export default {
+  title: 'Components/AdvancedDataTable',
+  component: AdvancedDataTable,
+  argTypes: {
+    selectionMode: {
+      control: { type: 'select' },
+      options: ['single', 'multiple', null],
+    },
+  },
+} as Meta<typeof AdvancedDataTable>;
+
+const sampleColumns: Column[] = [
+  { field: 'id', header: 'ID', type: 'number', sortable: true, align: 'right' },
+  {
+    field: 'name',
+    header: 'Full Name',
+    type: 'text',
+    sortable: true,
+    filterable: true,
+  },
+  {
+    field: 'salary',
+    header: 'Salary',
+    type: 'currency',
+    sortable: true,
+    formatOptions: { currency: 'IRR' },
+    align: 'right',
+  },
+  { field: 'hireDate', header: 'Hire Date', type: 'date-fa', sortable: true },
+  { field: 'active', header: 'Active', type: 'boolean', sortable: true },
+  { field: 'resume', header: 'Resume File', type: 'file' },
+];
+
+const sampleData = [
+  {
+    id: 1,
+    name: 'Ali Rezaei',
+    salary: 12000000,
+    hireDate: '2023-02-15',
+    active: true,
+    resume: '/files/ali.pdf',
+  },
+  {
+    id: 2,
+    name: 'Sara Ahmadi',
+    salary: 9500000,
+    hireDate: '2022-11-01',
+    active: false,
+    resume: '/files/sara.pdf',
+  },
+  {
+    id: 3,
+    name: 'Hossein Karimi',
+    salary: 15000000,
+    hireDate: '2023-07-20',
+    active: true,
+    resume: '/files/hossein.pdf',
+  },
+];
+
+const defaultPagination: Pagination = {
+  page: 1,
+  pageSize: 5,
+  total: sampleData.length,
+};
+
+export const Basic: StoryFn<typeof AdvancedDataTable> = args => ({
+  components: { AdvancedDataTable },
+  setup() {
+    return { args };
+  },
+  template: '<AdvancedDataTable v-bind="args" />',
+});
+
+Basic.args = {
+  columns: sampleColumns,
+  data: sampleData,
+  pagination: defaultPagination,
+  loading: false,
+  selectionMode: null,
+};
+
+export const AllColumnTypes: StoryFn<typeof AdvancedDataTable> = args => ({
+  components: { AdvancedDataTable },
+  setup() {
+    return { args };
+  },
+  template: `
+    <AdvancedDataTable v-bind="args">
+      <template #custom="{ row }">
+        <strong>{{ row.name }}</strong>
+      </template>
+    </AdvancedDataTable>
+  `,
+});
+
+AllColumnTypes.args = {
+  columns: [
+    { field: 'text', header: 'Text' },
+    { field: 'num', header: 'Number', type: 'number' },
+    { field: 'curr', header: 'Currency', type: 'currency', formatOptions: { currency: 'USD' } },
+    { field: 'date', header: 'Date', type: 'date' },
+    { field: 'dateFa', header: 'Date FA', type: 'date-fa' },
+    { field: 'bool', header: 'Boolean', type: 'boolean' },
+    { field: 'file', header: 'File', type: 'file' },
+    { field: 'slot', header: 'Slot', type: 'slot', slotName: 'custom' },
+  ] as Column[],
+  data: [
+    {
+      text: 'Row1',
+      num: 1000,
+      curr: 2000,
+      date: '2023-09-01',
+      dateFa: '2023-09-01',
+      bool: true,
+      file: '#',
+      name: 'Custom1',
+    },
+    {
+      text: 'Row2',
+      num: 2000,
+      curr: 3000,
+      date: '2023-09-02',
+      dateFa: '2023-09-02',
+      bool: false,
+      file: '#',
+      name: 'Custom2',
+    },
+  ],
+  pagination: { page: 1, pageSize: 10, total: 2 },
+  selectionMode: null,
+  loading: false,
+};

--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.vue
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.vue
@@ -1,0 +1,153 @@
+<!-- AdvancedDataTable.vue - Reusable data table component -->
+<template>
+  <div :class="styles.root">
+    <table :class="styles.table">
+      <thead>
+        <TableHeader :columns="columns" :sort-state="sortState" @sort="onSort" />
+        <TableFilters v-if="hasFilters" :columns="columns" :model="filters" @filter="onFilter" />
+      </thead>
+      <TableBody
+        :columns="columns"
+        :rows="paginatedData"
+        :loading="loading"
+        :empty="!loading && paginatedData.length === 0"
+        :selection-mode="selectionMode"
+        :model-value="selection"
+        @update:modelValue="onSelection"
+        v-slots="$slots"
+      />
+    </table>
+    <TableFooter
+      v-if="paginationState"
+      :pagination="paginationState"
+      @update:pagination="onPagination"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import styles from './AdvancedDataTable.module.css';
+import type {
+  Column,
+  Pagination,
+  SelectionMode,
+  SortState,
+  FilterModel,
+} from './types';
+import TableHeader from './components/TableHeader.vue';
+import TableBody from './components/TableBody.vue';
+import TableFooter from './components/TableFooter.vue';
+import TableFilters from './components/TableFilters.vue';
+
+const props = defineProps<{
+  columns: Column[];
+  data: any[];
+  pagination?: Pagination;
+  selectionMode?: SelectionMode;
+  modelValue?: any[];
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: any[]): void;
+  (e: 'update:pagination', value: Pagination): void;
+  (e: 'sort', value: SortState): void;
+  (e: 'filter', value: FilterModel): void;
+}>();
+
+const sortState = ref<SortState | null>(null);
+const filters = ref<FilterModel>({});
+
+const selection = ref<any[]>(props.modelValue ?? []);
+watch(
+  () => props.modelValue,
+  v => {
+    selection.value = v ?? [];
+  }
+);
+
+const paginationState = ref<Pagination | undefined>(
+  props.pagination ? { ...props.pagination } : undefined
+);
+watch(
+  () => props.pagination,
+  v => {
+    paginationState.value = v ? { ...v } : undefined;
+  },
+  { deep: true }
+);
+
+const filteredData = computed(() => {
+  if (!Object.keys(filters.value).length) return props.data;
+  return props.data.filter(row => {
+    return Object.entries(filters.value).every(([field, value]) => {
+      if (value == null || value === '') return true;
+      const cell = row[field as keyof typeof row];
+      return String(cell ?? '')
+        .toLowerCase()
+        .includes(String(value).toLowerCase());
+    });
+  });
+});
+
+const sortedData = computed(() => {
+  if (!sortState.value) return filteredData.value;
+  const { field, order } = sortState.value;
+  return [...filteredData.value].sort((a, b) => {
+    const av = a[field];
+    const bv = b[field];
+    if (av == null) return -1;
+    if (bv == null) return 1;
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return order === 'asc' ? av - bv : bv - av;
+    }
+    return order === 'asc'
+      ? String(av).localeCompare(String(bv))
+      : String(bv).localeCompare(String(av));
+  });
+});
+
+const paginatedData = computed(() => {
+  if (!paginationState.value) return sortedData.value;
+  const start = (paginationState.value.page - 1) * paginationState.value.pageSize;
+  const end = start + paginationState.value.pageSize;
+  return sortedData.value.slice(start, end);
+});
+
+watch(
+  sortedData,
+  val => {
+    if (paginationState.value) {
+      paginationState.value.total = val.length;
+    }
+  },
+  { immediate: true }
+);
+
+const hasFilters = computed(() => props.columns.some(c => c.filterable));
+
+function onSort(field: string) {
+  if (sortState.value && sortState.value.field === field) {
+    sortState.value.order = sortState.value.order === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortState.value = { field, order: 'asc' };
+  }
+  emit('sort', sortState.value);
+}
+
+function onFilter(model: FilterModel) {
+  filters.value = model;
+  emit('filter', model);
+}
+
+function onPagination(pag: Pagination) {
+  paginationState.value = pag;
+  emit('update:pagination', pag);
+}
+
+function onSelection(val: any[]) {
+  selection.value = val;
+  emit('update:modelValue', val);
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/components/TableBody.vue
+++ b/ui-library/components/AdvancedDataTable/components/TableBody.vue
@@ -1,0 +1,108 @@
+<!-- TableBody.vue - Renders table body rows and handles selection -->
+<template>
+  <tbody>
+    <tr v-if="loading" :class="styles.loading">
+      <td :colspan="columns.length">Loading...</td>
+    </tr>
+    <tr v-else-if="empty" :class="styles.empty">
+      <td :colspan="columns.length">No records found</td>
+    </tr>
+    <tr
+      v-else
+      v-for="(row, rowIndex) in rows"
+      :key="rowIndex"
+      :class="[styles.row, { [styles.selected]: isSelected(row) }]"
+      tabindex="0"
+      @click="toggle(row)"
+      @keydown.enter.prevent="toggle(row)"
+      @keydown.space.prevent="toggle(row)"
+    >
+      <td
+        v-for="col in columns"
+        :key="col.field"
+        :class="styles.cell"
+        :style="{ textAlign: defaultAlign(col) }"
+      >
+        <template v-if="col.type === 'number'">
+          {{ formatNumber(row[col.field], undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'currency'">
+          {{ formatCurrency(row[col.field], col.formatOptions?.currency, undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'date'">
+          {{ formatDate(row[col.field], undefined, col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'date-fa'">
+          {{ formatDateFa(row[col.field], col.formatOptions) }}
+        </template>
+        <template v-else-if="col.type === 'boolean'">
+          <span :class="styles.boolean">{{ formatBoolean(row[col.field]) }}</span>
+        </template>
+        <template v-else-if="col.type === 'file'">
+          <a v-if="row[col.field]" :href="row[col.field]" download target="_blank">📄</a>
+        </template>
+        <template
+          v-else-if="col.type === 'slot' && col.slotName && slots[col.slotName]"
+        >
+          <component :is="slots[col.slotName]" :row="row" />
+        </template>
+        <template v-else>
+          {{ row[col.field] }}
+        </template>
+      </td>
+    </tr>
+  </tbody>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, useSlots } from 'vue';
+import styles from '../AdvancedDataTable.module.css';
+import type { Column, SelectionMode } from '../types';
+import { formatNumber, formatCurrency, formatDate, formatDateFa, formatBoolean } from '../utils/formatters';
+
+const props = defineProps<{
+  columns: Column[];
+  rows: any[];
+  selectionMode?: SelectionMode;
+  modelValue: any[];
+  loading?: boolean;
+  empty?: boolean;
+}>();
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: any[]): void }>();
+const slots = useSlots();
+
+const selected = ref<any[]>(props.modelValue ?? []);
+
+watch(
+  () => props.modelValue,
+  v => {
+    selected.value = v ?? [];
+  }
+);
+
+function isSelected(row: any): boolean {
+  return selected.value.includes(row);
+}
+
+function toggle(row: any) {
+  if (!props.selectionMode) return;
+  let next: any[] = [];
+  if (props.selectionMode === 'single') {
+    next = isSelected(row) ? [] : [row];
+  } else {
+    next = isSelected(row)
+      ? selected.value.filter(r => r !== row)
+      : [...selected.value, row];
+  }
+  selected.value = next;
+  emit('update:modelValue', next);
+}
+
+function defaultAlign(col: Column): 'left' | 'right' | 'center' {
+  if (col.align) return col.align;
+  if (col.type === 'number' || col.type === 'currency') return 'right';
+  if (col.type === 'boolean') return 'center';
+  return 'left';
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/components/TableFilters.vue
+++ b/ui-library/components/AdvancedDataTable/components/TableFilters.vue
@@ -1,0 +1,34 @@
+<!-- TableFilters.vue - Renders filter inputs for filterable columns -->
+<template>
+  <tr>
+    <th v-for="col in columns" :key="col.field">
+      <input
+        v-if="col.filterable"
+        type="text"
+        v-model="local[col.field]"
+        @input="emitFilter"
+      />
+    </th>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import type { Column, FilterModel } from '../types';
+
+const props = defineProps<{ columns: Column[]; model: FilterModel }>();
+const emit = defineEmits<{ (e: 'filter', model: FilterModel): void }>();
+
+const local = ref<Record<string, string>>({ ...props.model });
+
+watch(
+  () => props.model,
+  v => {
+    local.value = { ...v };
+  }
+);
+
+function emitFilter() {
+  emit('filter', { ...local.value });
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/components/TableFooter.vue
+++ b/ui-library/components/AdvancedDataTable/components/TableFooter.vue
@@ -1,0 +1,18 @@
+<!-- TableFooter.vue - Container for pagination or other footer elements -->
+<template>
+  <div>
+    <TablePagination :pagination="pagination" @update:pagination="update" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import TablePagination from './TablePagination.vue';
+import type { Pagination } from '../types';
+
+const props = defineProps<{ pagination: Pagination }>();
+const emit = defineEmits<{ (e: 'update:pagination', value: Pagination): void }>();
+
+function update(value: Pagination) {
+  emit('update:pagination', value);
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/components/TableHeader.vue
+++ b/ui-library/components/AdvancedDataTable/components/TableHeader.vue
@@ -1,0 +1,35 @@
+<!-- TableHeader.vue - Renders table header cells and handles sorting -->
+<template>
+  <tr :class="styles.header">
+    <th
+      v-for="col in columns"
+      :key="col.field"
+      :style="{ width: col.width, textAlign: col.align || 'left' }"
+      :class="{ [styles.sortable]: col.sortable }"
+      :tabindex="col.sortable ? 0 : undefined"
+      @click="emitSort(col)"
+      @keydown.enter.prevent="emitSort(col)"
+      @keydown.space.prevent="emitSort(col)"
+    >
+      <span>{{ col.header }}</span>
+      <span v-if="col.sortable">
+        <span v-if="sortState && sortState.field === col.field">
+          {{ sortState.order === 'asc' ? '▲' : '▼' }}
+        </span>
+        <span v-else>↕</span>
+      </span>
+    </th>
+  </tr>
+</template>
+
+<script setup lang="ts">
+import styles from '../AdvancedDataTable.module.css';
+import type { Column, SortState } from '../types';
+
+const props = defineProps<{ columns: Column[]; sortState: SortState | null }>();
+const emit = defineEmits<{ (e: 'sort', field: string): void }>();
+
+function emitSort(col: Column) {
+  if (col.sortable) emit('sort', col.field);
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/components/TablePagination.vue
+++ b/ui-library/components/AdvancedDataTable/components/TablePagination.vue
@@ -1,0 +1,31 @@
+<!-- TablePagination.vue - Basic pagination controls -->
+<template>
+  <div :class="styles.pagination">
+    <button type="button" @click="prev" :disabled="pagination.page <= 1">◀</button>
+    <span>{{ pagination.page }} / {{ pageCount }}</span>
+    <button type="button" @click="next" :disabled="pagination.page >= pageCount">▶</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import styles from '../AdvancedDataTable.module.css';
+import type { Pagination } from '../types';
+
+const props = defineProps<{ pagination: Pagination }>();
+const emit = defineEmits<{ (e: 'update:pagination', value: Pagination): void }>();
+
+const pageCount = computed(() => Math.max(1, Math.ceil(props.pagination.total / props.pagination.pageSize)));
+
+function prev() {
+  if (props.pagination.page > 1) {
+    emit('update:pagination', { ...props.pagination, page: props.pagination.page - 1 });
+  }
+}
+
+function next() {
+  if (props.pagination.page < pageCount.value) {
+    emit('update:pagination', { ...props.pagination, page: props.pagination.page + 1 });
+  }
+}
+</script>

--- a/ui-library/components/AdvancedDataTable/types.ts
+++ b/ui-library/components/AdvancedDataTable/types.ts
@@ -1,0 +1,28 @@
+// types.ts - Interfaces for AdvancedDataTable component
+
+export interface Column {
+  field: string;
+  header: string;
+  type?: 'text' | 'number' | 'currency' | 'date-fa' | 'date' | 'boolean' | 'file' | 'slot';
+  sortable?: boolean;
+  filterable?: boolean;
+  width?: string;
+  align?: 'left' | 'center' | 'right';
+  slotName?: string;
+  formatOptions?: Record<string, any>;
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export type SelectionMode = 'single' | 'multiple' | null;
+
+export interface SortState {
+  field: string;
+  order: 'asc' | 'desc';
+}
+
+export type FilterModel = Record<string, any>;

--- a/ui-library/components/AdvancedDataTable/utils/formatters.ts
+++ b/ui-library/components/AdvancedDataTable/utils/formatters.ts
@@ -1,0 +1,30 @@
+// formatters.ts - Helper formatting functions for AdvancedDataTable
+
+export function formatNumber(value: number, locale = 'fa-IR', options?: Intl.NumberFormatOptions): string {
+  return new Intl.NumberFormat(locale, options).format(value);
+}
+
+export function formatCurrency(
+  value: number,
+  currency: string = 'IRR',
+  locale = 'fa-IR',
+  options?: Intl.NumberFormatOptions
+): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency, ...options }).format(value);
+}
+
+export function formatDate(
+  value: string | number | Date,
+  locale = 'en-US',
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(new Date(value));
+}
+
+export function formatDateFa(value: string | number | Date, options?: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('fa-IR-u-ca-persian', options).format(new Date(value));
+}
+
+export function formatBoolean(value: boolean): string {
+  return value ? '✔︎' : '✘';
+}

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -20,3 +20,4 @@ export { default as BaseSpeedDial } from './BaseSpeedDial/BaseSpeedDial.vue';
 export { default as BaseImage } from './BaseImage/BaseImage.vue';
 export { default as BaseIcon } from './BaseIcon/BaseIcon.vue';
 export { default as BaseDataTable } from './BaseDataTable/BaseDataTable.vue';
+export { default as AdvancedDataTable } from './AdvancedDataTable/AdvancedDataTable.vue';


### PR DESCRIPTION
## Summary
- add AdvancedDataTable with sorting, filtering, pagination, and selection
- support rich column types and formatting utilities
- include storybook stories and styles with CSS variables

## Testing
- `npm test` *(fails: Missing script)*
- `npx vite build` *(fails: Permission denied for vite)*

------
https://chatgpt.com/codex/tasks/task_e_689677d56d588321bd0b3513b4623950