### PR TITLE
chore: remove missing BaseCollapse export

### DIFF
--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -1,7 +1,6 @@
 export { default as BaseBadge } from './BaseBadge/BaseBadge.vue';
 export { default as BaseButton } from './BaseButton/BaseButton.vue';
 export { default as BaseCheckbox } from './BaseCheckbox/BaseCheckbox.vue';
-export { default as BaseCollapse } from './BaseCollapse/BaseCollapse.vue';
 export { default as BaseDropdown } from './BaseDropdown/BaseDropdown.vue';
 export { default as BaseInput } from './BaseInput/BaseInput.vue';
 export { default as BaseLabel } from './BaseLabel/BaseLabel.vue';

--- a/ui-library/types/index.d.ts
+++ b/ui-library/types/index.d.ts
@@ -1,6 +1,5 @@
 export { default as BaseButton } from '../components/BaseButton/BaseButton.vue';
 export { default as BaseCheckbox } from '../components/BaseCheckbox/BaseCheckbox.vue';
-export { default as BaseCollapse } from '../components/BaseCollapse/BaseCollapse.vue';
 export { default as BaseDropdown } from '../components/BaseDropdown/BaseDropdown.vue';
 export { default as BaseInput } from '../components/BaseInput/BaseInput.vue';
 export { default as BaseModal } from '../components/BaseModal/BaseModal.vue';


### PR DESCRIPTION
## Summary
- remove BaseCollapse export from components and types index files
- ensures build no longer fails with missing module

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68967f3ce73c8321b24c53032ca04c35