### PR TITLE
feat: add action slots to AdvancedDataTable

### DIFF
--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.module.css
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.module.css
@@ -38,6 +38,13 @@
   color: var(--color-text);
 }
 
+/* Wrapper for custom slot content to align action buttons */
+.slot-container {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .selected {
   background: var(--table-row-selected-bg);
 }

--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
@@ -1,5 +1,6 @@
 // AdvancedDataTable.stories.ts - Final demo stories for AdvancedDataTable
 import AdvancedDataTable from './AdvancedDataTable.vue';
+import BaseButton from '../BaseButton/BaseButton.vue';
 import type { Meta, StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 import { datasetColumns, generateDataset } from './utils/datasetGenerator';
@@ -142,6 +143,33 @@ export const CustomStates: StoryFn<typeof AdvancedDataTable> = () => ({
     <AdvancedDataTable :columns="columns" :data="data" :loading="loading">
       <template #emptyState><div>No data!</div></template>
       <template #loadingState><div>Loading please wait...</div></template>
+    </AdvancedDataTable>
+  `,
+});
+
+// Row action buttons using custom slot
+export const WithActions: StoryFn<typeof AdvancedDataTable> = () => ({
+  components: { AdvancedDataTable, BaseButton },
+  setup() {
+    const data = generateDataset(5);
+    const columns = [
+      ...datasetColumns,
+      { field: 'actions', header: 'Actions', type: 'slot', slotName: 'actions' },
+    ];
+    function onEdit(payload: any) {
+      console.log('edit', payload);
+    }
+    function onDelete(payload: any) {
+      console.log('delete', payload);
+    }
+    return { data, columns, onEdit, onDelete };
+  },
+  template: `
+    <AdvancedDataTable :columns="columns" :data="data" @edit="onEdit" @delete="onDelete">
+      <template #actions="{ row, index }">
+        <BaseButton variant="primary" @click.stop="$emit('edit', { row, index })">Edit</BaseButton>
+        <BaseButton variant="danger" @click.stop="$emit('delete', { row, index })">Delete</BaseButton>
+      </template>
     </AdvancedDataTable>
   `,
 });

--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.vue
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.vue
@@ -92,6 +92,7 @@ import type {
   RowExpansionMode,
   LazyLoadEvent,
   ServerRequestQuery,
+  DataTableColumnSlotProps,
 } from './types';
 import TableHeader from './components/TableHeader.vue';
 import TableBody from './components/TableBody.vue';
@@ -129,6 +130,9 @@ const emit = defineEmits<{
   (e: 'column-reorder', columns: Column[]): void;
   (e: 'lazy-load', evt: LazyLoadEvent): void;
   (e: 'server-request', query: ServerRequestQuery): void;
+  (e: 'edit', payload: DataTableColumnSlotProps): void;
+  (e: 'delete', payload: DataTableColumnSlotProps): void;
+  (e: 'add'): void;
 }>();
 
 const sortState = ref<SortState[]>([]);

--- a/ui-library/components/AdvancedDataTable/components/TableBody.vue
+++ b/ui-library/components/AdvancedDataTable/components/TableBody.vue
@@ -43,7 +43,13 @@
           :style="{ textAlign: defaultAlign(col) }"
         >
           <template v-if="slots[`cell-${col.field}`]">
-            <component :is="slots[`cell-${col.field}`]" :row="row" :value="row[col.field]" :column="col" />
+            <component
+              :is="slots[`cell-${col.field}`]"
+              :row="row"
+              :value="row[col.field]"
+              :column="col"
+              :index="rowIndex"
+            />
           </template>
           <template v-else-if="col.type === 'number'">
             {{ formatNumber(row[col.field], undefined, col.formatOptions) }}
@@ -73,7 +79,9 @@
           <template
             v-else-if="col.type === 'slot' && col.slotName && slots[col.slotName]"
           >
-            <component :is="slots[col.slotName]" :row="row" />
+            <div :class="styles['slot-container']" @click.stop>
+              <component :is="slots[col.slotName]" :row="row" :index="rowIndex" />
+            </div>
           </template>
           <template v-else>
             {{ row[col.field] }}

--- a/ui-library/components/AdvancedDataTable/types.ts
+++ b/ui-library/components/AdvancedDataTable/types.ts
@@ -14,6 +14,7 @@ export interface Column {
   filterSlotName?: string;
   width?: string;
   align?: 'left' | 'center' | 'right';
+  /** Slot name for custom cell rendering when type is 'slot' */
   slotName?: string;
   formatOptions?: Record<string, any>;
 }
@@ -49,3 +50,17 @@ export interface ServerRequestQuery {
 }
 
 export type RowExpansionMode = 'single' | 'multiple';
+
+/** Props passed to custom column slots (e.g. action buttons) */
+export interface DataTableColumnSlotProps<Row = any> {
+  row: Row;
+  index: number;
+}
+
+/** Props passed to generic cell slots using "cell-<field>" naming */
+export interface DataTableCellSlotProps<Row = any, Value = any> {
+  row: Row;
+  value: Value;
+  column: Column;
+  index: number;
+}


### PR DESCRIPTION
## Summary
- allow custom column slots with row and index props
- add typed events for edit/delete/add actions
- demonstrate action slot usage in storybook

## Testing
- `npm run build` *(fails: Could not resolve "./BaseCollapse/BaseCollapse.vue" from "components/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68967f22abfc8321869e5867f00f16f1