### PR TITLE
feat: preload themes for AdvancedDataTable stories

### DIFF
--- a/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
+++ b/ui-library/components/AdvancedDataTable/AdvancedDataTable.stories.ts
@@ -6,6 +6,9 @@ import { ref } from 'vue';
 import { datasetColumns, generateDataset } from './utils/datasetGenerator';
 import type { Pagination, ServerRequestQuery } from './types';
 import { applyFilters } from './utils/filterUtils';
+import lightThemeHref from './themes/light.css?url';
+import darkThemeHref from './themes/dark.css?url';
+import brandXThemeHref from './themes/brandX.css?url';
 
 export default {
   title: 'Components/AdvancedDataTable',
@@ -80,10 +83,24 @@ export const Theming: StoryFn<typeof AdvancedDataTable> = () => ({
   components: { AdvancedDataTable },
   setup() {
     const data = generateDataset(20);
-    function setTheme(t: string) {
-      import(`./themes/${t}.css`);
+    const themes: Record<string, HTMLLinkElement> = {
+      light: createLink(lightThemeHref, true),
+      dark: createLink(darkThemeHref),
+      brandX: createLink(brandXThemeHref),
+    };
+    function createLink(href: string, enabled = false) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.disabled = !enabled;
+      document.head.appendChild(link);
+      return link;
     }
-    setTheme('light');
+    function setTheme(t: string) {
+      Object.entries(themes).forEach(([key, link]) => {
+        link.disabled = key !== t;
+      });
+    }
     return { data, columns: datasetColumns, setTheme };
   },
   template: `


### PR DESCRIPTION
## Summary
- preload theme CSS
- synchronously switch themes via link elements

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: sh: 1: vite: Permission denied)


------
https://chatgpt.com/codex/tasks/task_e_6896ddd27f3c8321971f785db672355f