### PR TITLE
feat: add segment component suite

### DIFF
--- a/ui-library/__tests__/BaseSegment.spec.ts
+++ b/ui-library/__tests__/BaseSegment.spec.ts
@@ -1,0 +1,63 @@
+import { render, fireEvent } from '@testing-library/vue';
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import { BaseSegment, BaseSegmentButton } from '../components/segment';
+import segmentStyles from '../components/segment/BaseSegment.module.css';
+
+describe('BaseSegment', () => {
+  it('updates value on click', async () => {
+    const model = ref<any>(null);
+    const { getByRole } = render({
+      components: { BaseSegment, BaseSegmentButton },
+      setup() { return { model }; },
+      template: `
+        <BaseSegment v-model="model">
+          <BaseSegmentButton value="a" label="A" />
+          <BaseSegmentButton value="b" label="B" />
+        </BaseSegment>
+      `,
+    });
+    const a = getByRole('radio', { name: 'A' });
+    await fireEvent.click(a);
+    expect(model.value).toBe('a');
+  });
+
+  it('keyboard navigation moves focus', async () => {
+    const { getByRole } = render({
+      components: { BaseSegment, BaseSegmentButton },
+      template: `
+        <BaseSegment>
+          <BaseSegmentButton value="a" label="A" />
+          <BaseSegmentButton value="b" label="B" />
+        </BaseSegment>
+      `,
+    });
+    const a = getByRole('radio', { name: 'A' });
+    const b = getByRole('radio', { name: 'B' });
+    a.focus();
+    await fireEvent.keyDown(a, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(b);
+  });
+
+  it('multiple mode toggles array', async () => {
+    const model = ref<string[]>([]);
+    const { getByRole } = render({
+      components: { BaseSegment, BaseSegmentButton },
+      setup() { return { model }; },
+      template: `
+        <BaseSegment v-model="model" multiple>
+          <BaseSegmentButton value="a" label="A" />
+          <BaseSegmentButton value="b" label="B" />
+        </BaseSegment>
+      `,
+    });
+    const a = getByRole('button', { name: 'A' });
+    await fireEvent.click(a);
+    expect(model.value).toContain('a');
+  });
+
+  it('applies scrollable class', () => {
+    const { container } = render(BaseSegment, { props: { scrollable: true } });
+    expect(container.firstChild).toHaveClass(segmentStyles.scrollable);
+  });
+});

--- a/ui-library/components/index.ts
+++ b/ui-library/components/index.ts
@@ -20,3 +20,4 @@ export { default as BaseImage } from './BaseImage/BaseImage.vue';
 export { default as BaseIcon } from './BaseIcon/BaseIcon.vue';
 export { default as BaseDataTable } from './BaseDataTable/BaseDataTable.vue';
 export { default as AdvancedDataTable } from './AdvancedDataTable/AdvancedDataTable.vue';
+export * from './segment';

--- a/ui-library/components/segment/BaseSegment.module.css
+++ b/ui-library/components/segment/BaseSegment.module.css
@@ -1,0 +1,174 @@
+.segment {
+  --segment-color: var(--color-primary);
+  --segment-color-on: var(--color-on-primary);
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  background: var(--color-surface);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.scrollable {
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.scrollable::before,
+.scrollable::after {
+  content: '';
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  width: var(--space-md);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.scrollable::before {
+  left: 0;
+  background: linear-gradient(to right, var(--color-surface), transparent);
+}
+
+.scrollable::after {
+  right: 0;
+  background: linear-gradient(to left, var(--color-surface), transparent);
+}
+
+:global(html[dir='rtl']) .scrollable::before {
+  right: 0;
+  left: auto;
+  background: linear-gradient(to left, var(--color-surface), transparent);
+}
+
+:global(html[dir='rtl']) .scrollable::after {
+  left: 0;
+  right: auto;
+  background: linear-gradient(to right, var(--color-surface), transparent);
+}
+
+.indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--segment-color);
+  transition: transform var(--transition-base), width var(--transition-base);
+  will-change: transform, width;
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-full);
+}
+
+.mode_md .indicator {
+  height: 2px;
+  top: auto;
+  bottom: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.readonly {
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.multiple .indicator {
+  display: none;
+}
+
+.sm {
+  --segment-height: calc(var(--space-md) * 2);
+}
+
+.md {
+  --segment-height: calc(var(--space-lg) * 2);
+}
+
+.lg {
+  --segment-height: calc(var(--space-lg) * 2.5);
+}
+
+.pill {
+  border-radius: var(--radius-full);
+}
+
+.rounded {
+  border-radius: var(--radius-md);
+}
+
+.variant_primary {
+  --segment-color: var(--color-primary);
+  --segment-color-on: var(--color-on-primary);
+}
+
+.variant_secondary {
+  --segment-color: var(--color-secondary);
+  --segment-color-on: var(--color-on-secondary);
+}
+
+.variant_success {
+  --segment-color: var(--color-success);
+  --segment-color-on: var(--color-on-success);
+}
+
+.variant_warning {
+  --segment-color: var(--color-warning);
+  --segment-color-on: var(--color-on-warning);
+}
+
+.variant_info {
+  --segment-color: var(--color-info);
+  --segment-color-on: var(--color-on-info);
+}
+
+.variant_error {
+  --segment-color: var(--color-error);
+  --segment-color-on: var(--color-on-error);
+}
+
+.variant_outline {
+  --segment-color: var(--color-border);
+  --segment-color-on: var(--color-text);
+}
+
+.variant_ghost {
+  --segment-color: var(--color-text);
+  --segment-color-on: var(--color-text);
+}
+
+.mode_ios {
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.mode_md {
+  background: transparent;
+}
+
+.mode_md.segment::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--color-border);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .indicator {
+    transition: none;
+  }
+}

--- a/ui-library/components/segment/BaseSegment.vue
+++ b/ui-library/components/segment/BaseSegment.vue
@@ -1,0 +1,312 @@
+<script setup lang="ts">
+import { ref, computed, provide, watch, onMounted, onBeforeUnmount, nextTick, useSlots } from 'vue';
+import BaseSegmentButton from './BaseSegmentButton.vue';
+import styles from './BaseSegment.module.css';
+
+export type SegmentValue = string | number;
+
+export interface SegmentItem {
+  label?: string;
+  value: SegmentValue;
+  icon?: string;
+  disabled?: boolean;
+}
+
+export interface BaseSegmentProps {
+  modelValue?: SegmentValue | SegmentValue[] | null;
+  items?: Array<SegmentItem | SegmentValue>;
+  label?: string;
+  name?: string;
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'info' | 'error' | 'outline' | 'ghost';
+  shape?: 'pill' | 'rounded';
+  fullWidth?: boolean;
+  disabled?: boolean;
+  readonly?: boolean;
+  multiple?: boolean;
+  required?: boolean;
+  allowEmpty?: boolean;
+  ariaLabel?: string;
+  scrollable?: boolean;
+  mode?: 'ios' | 'md';
+}
+
+export const segmentInjectionKey = Symbol('BaseSegment');
+
+interface SegmentItemData {
+  el: HTMLElement;
+  disabled: boolean;
+}
+
+interface SegmentContext {
+  size: BaseSegmentProps['size'];
+  variant: BaseSegmentProps['variant'];
+  mode: BaseSegmentProps['mode'];
+  disabled: ComputedRef<boolean>;
+  readonly: ComputedRef<boolean>;
+  multiple: boolean;
+  select: (v: SegmentValue) => void;
+  isActive: (v: SegmentValue) => boolean;
+  register: (v: SegmentValue, el: HTMLElement, disabled: boolean) => void;
+  unregister: (v: SegmentValue) => void;
+  setDisabled: (v: SegmentValue, disabled: boolean) => void;
+  getTabIndex: (v: SegmentValue, disabled: boolean) => number;
+}
+
+const props = withDefaults(defineProps<BaseSegmentProps>(), {
+  size: 'md',
+  variant: 'primary',
+  shape: 'pill',
+  fullWidth: false,
+  disabled: false,
+  readonly: false,
+  multiple: false,
+  required: false,
+  allowEmpty: true,
+  scrollable: false,
+  mode: 'md',
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: SegmentValue | SegmentValue[] | null): void;
+  (e: 'change', value: SegmentValue | SegmentValue[] | null): void;
+}>();
+
+const slots = useSlots();
+const hasDefaultSlot = computed(() => !!slots.default);
+
+const root = ref<HTMLElement>();
+const indicatorRef = ref<HTMLElement>();
+const internalValue = ref<SegmentValue | SegmentValue[] | null>(props.modelValue ?? (props.multiple ? [] : null));
+
+watch(() => props.modelValue, v => {
+  internalValue.value = v ?? (props.multiple ? [] : null);
+});
+
+watch(internalValue, v => emit('update:modelValue', v));
+
+function isActive(v: SegmentValue): boolean {
+  return props.multiple
+    ? Array.isArray(internalValue.value) && internalValue.value.includes(v)
+    : internalValue.value === v;
+}
+
+function select(v: SegmentValue) {
+  if (props.disabled || props.readonly) return;
+  if (props.multiple) {
+    const arr = Array.isArray(internalValue.value) ? [...internalValue.value] : [];
+    const idx = arr.indexOf(v);
+    if (idx >= 0) {
+      if (props.required && arr.length <= 1 && !props.allowEmpty) return;
+      arr.splice(idx, 1);
+    } else {
+      arr.push(v);
+    }
+    internalValue.value = arr;
+    emit('change', internalValue.value);
+  } else {
+    const current = internalValue.value as SegmentValue | null;
+    if (current === v) {
+      if (!props.allowEmpty) return;
+      internalValue.value = null;
+    } else {
+      internalValue.value = v;
+    }
+    emit('change', internalValue.value);
+  }
+  nextTick(updateIndicator);
+}
+
+const items = new Map<SegmentValue, SegmentItemData>();
+const order = ref<SegmentValue[]>([]);
+
+function register(value: SegmentValue, el: HTMLElement, disabled: boolean) {
+  items.set(value, { el, disabled });
+  if (!order.value.includes(value)) order.value.push(value);
+  ro.observe(el);
+  nextTick(updateIndicator);
+}
+
+function unregister(value: SegmentValue) {
+  const item = items.get(value);
+  if (item) ro.unobserve(item.el);
+  items.delete(value);
+  order.value = order.value.filter(v => v !== value);
+  nextTick(updateIndicator);
+}
+
+function setDisabled(value: SegmentValue, disabled: boolean) {
+  const item = items.get(value);
+  if (item) item.disabled = disabled;
+}
+
+function getTabIndex(value: SegmentValue, disabled: boolean) {
+  if (props.disabled || disabled) return -1;
+  if (props.multiple) return 0;
+  if (isActive(value)) return 0;
+  const current = internalValue.value as SegmentValue | null;
+  if (current == null) {
+    const first = order.value.find(v => !items.get(v)?.disabled);
+    return value === first ? 0 : -1;
+  }
+  return -1;
+}
+
+const ctx: SegmentContext = {
+  size: props.size,
+  variant: props.variant,
+  mode: props.mode,
+  disabled: computed(() => props.disabled),
+  readonly: computed(() => props.readonly),
+  multiple: props.multiple,
+  select,
+  isActive,
+  register,
+  unregister,
+  setDisabled,
+  getTabIndex,
+};
+
+provide(segmentInjectionKey, ctx);
+
+const indicatorWidth = ref(0);
+const indicatorX = ref(0);
+
+function updateIndicator() {
+  if (props.multiple) return;
+  const val = internalValue.value as SegmentValue | null;
+  if (!val) {
+    indicatorWidth.value = 0;
+    indicatorX.value = 0;
+    return;
+  }
+  const item = items.get(val);
+  const el = item?.el;
+  if (!el || !root.value) return;
+  const parent = root.value;
+  const parentRect = parent.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const dir = getComputedStyle(parent).direction;
+  const scrollLeft = parent.scrollLeft;
+  let x = elRect.left - parentRect.left + scrollLeft;
+  if (dir === 'rtl') {
+    x = parentRect.right - elRect.right + scrollLeft;
+  }
+  indicatorWidth.value = elRect.width;
+  indicatorX.value = x;
+}
+
+const ro = new ResizeObserver(() => updateIndicator());
+
+onMounted(() => {
+  if (root.value) ro.observe(root.value);
+  updateIndicator();
+});
+
+onBeforeUnmount(() => ro.disconnect());
+
+function onKeydown(e: KeyboardEvent) {
+  const keys = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End', ' ', 'Enter'];
+  if (!keys.includes(e.key)) return;
+  const enabled = order.value.filter(v => !items.get(v)?.disabled);
+  const activeEl = document.activeElement as HTMLElement | null;
+  const current = enabled.find(v => items.get(v)?.el === activeEl);
+  let index = current ? enabled.indexOf(current) : -1;
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+    index = index < enabled.length - 1 ? index + 1 : 0;
+    items.get(enabled[index])?.el.focus();
+    e.preventDefault();
+  } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+    index = index > 0 ? index - 1 : enabled.length - 1;
+    items.get(enabled[index])?.el.focus();
+    e.preventDefault();
+  } else if (e.key === 'Home') {
+    items.get(enabled[0])?.el.focus();
+    e.preventDefault();
+  } else if (e.key === 'End') {
+    items.get(enabled[enabled.length - 1])?.el.focus();
+    e.preventDefault();
+  } else if (e.key === ' ' || e.key === 'Enter') {
+    if (current != null) select(current);
+    e.preventDefault();
+  }
+}
+
+const normalizedItems = computed<SegmentItem[]>(() => {
+  if (!props.items) return [];
+  return props.items.map(i => {
+    if (typeof i === 'object' && 'value' in i) return i as SegmentItem;
+    return { label: String(i), value: i as SegmentValue };
+  });
+});
+
+const liveMessage = computed(() => {
+  if (props.multiple) {
+    return Array.isArray(internalValue.value) ? internalValue.value.join(', ') : '';
+  }
+  return internalValue.value != null ? String(internalValue.value) : '';
+});
+
+const hiddenValues = computed(() => {
+  if (!props.name) return [] as SegmentValue[];
+  if (props.multiple) return Array.isArray(internalValue.value) ? internalValue.value : [];
+  return internalValue.value != null ? [internalValue.value] : [];
+});
+
+const labelId = `seg-${Math.random().toString(36).slice(2, 8)}`;
+
+const cls = computed(() => [
+  styles.segment,
+  styles[`mode_${props.mode}`],
+  styles[props.size],
+  styles[props.shape],
+  styles[`variant_${props.variant}`],
+  props.fullWidth && styles.fullWidth,
+  props.scrollable && styles.scrollable,
+  props.disabled && styles.disabled,
+  props.readonly && styles.readonly,
+  props.multiple && styles.multiple,
+]);
+
+const indicatorStyle = computed(() => ({
+  width: `${indicatorWidth.value}px`,
+  transform: `translateX(${indicatorX.value}px)`,
+}));
+</script>
+
+<template>
+  <div
+    ref="root"
+    :class="cls"
+    :role="multiple ? 'group' : 'radiogroup'"
+    :aria-disabled="disabled ? 'true' : undefined"
+    :aria-readonly="readonly ? 'true' : undefined"
+    :aria-label="ariaLabel"
+    :aria-labelledby="label ? labelId : undefined"
+    @keydown="onKeydown"
+  >
+    <span v-if="label" :id="labelId" class="visually-hidden">{{ label }}</span>
+    <template v-if="!hasDefaultSlot && normalizedItems.length">
+      <BaseSegmentButton
+        v-for="item in normalizedItems"
+        :key="item.value"
+        :value="item.value"
+        :label="item.label"
+        :icon="item.icon"
+        :disabled="item.disabled"
+      />
+    </template>
+    <slot v-else />
+    <div v-if="!multiple" ref="indicatorRef" :class="styles.indicator" :style="indicatorStyle" />
+    <input
+      v-for="val in hiddenValues"
+      :key="val"
+      type="hidden"
+      :name="name"
+      :value="val"
+    />
+    <span aria-live="polite" class="visually-hidden">{{ liveMessage }}</span>
+  </div>
+</template>
+
+<style module src="./BaseSegment.module.css"></style>

--- a/ui-library/components/segment/BaseSegmentButton.module.css
+++ b/ui-library/components/segment/BaseSegmentButton.module.css
@@ -1,0 +1,101 @@
+.item {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  padding: 0 var(--space-md);
+  min-width: 44px;
+  min-height: var(--segment-height, 44px);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  scroll-snap-align: center;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.sm {
+  padding: 0 var(--space-sm);
+  font-size: var(--font-size-sm);
+}
+
+.lg {
+  padding: 0 var(--space-lg);
+  font-size: var(--font-size-lg);
+}
+
+.mode_ios {
+  border-radius: var(--radius-full);
+}
+
+.mode_md {
+  border-radius: var(--radius-md);
+}
+
+.item:hover:not(.disabled):not(.readonly) {
+  background: color-mix(in srgb, var(--segment-color) 10%, transparent);
+}
+
+.item:active:not(.disabled):not(.readonly) {
+  background: color-mix(in srgb, var(--segment-color) 20%, transparent);
+}
+
+.active {
+  color: var(--segment-color-on);
+  font-weight: var(--font-weight-bold);
+}
+
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.readonly {
+  cursor: not-allowed;
+}
+
+.iconWrap {
+  display: inline-flex;
+  margin-inline-end: var(--space-xs);
+}
+
+.iconOnly {
+  padding: 0;
+  width: var(--segment-height, 44px);
+  justify-content: center;
+}
+
+.iconOnly .iconWrap {
+  margin-inline-end: 0;
+}
+
+.label {
+  display: inline-block;
+}
+
+.item:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 var(--focus-ring-offset) var(--color-background),
+    0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width)) var(--focus-ring-color);
+}
+
+.variant_primary.active { color: var(--color-on-primary); }
+.variant_secondary.active { color: var(--color-on-secondary); }
+.variant_success.active { color: var(--color-on-success); }
+.variant_warning.active { color: var(--color-on-warning); }
+.variant_info.active { color: var(--color-on-info); }
+.variant_error.active { color: var(--color-on-error); }
+.variant_outline.active { color: var(--color-text); }
+.variant_ghost.active { color: var(--color-text); }
+
+@media (prefers-reduced-motion: reduce) {
+  .item {
+    transition: none;
+  }
+}

--- a/ui-library/components/segment/BaseSegmentButton.vue
+++ b/ui-library/components/segment/BaseSegmentButton.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { computed, inject, onMounted, onBeforeUnmount, ref, watch, useSlots } from 'vue';
+import BaseIcon from '../BaseIcon/BaseIcon.vue';
+import styles from './BaseSegmentButton.module.css';
+import { segmentInjectionKey, SegmentValue } from './BaseSegment.vue';
+
+interface Props {
+  value: SegmentValue;
+  label?: string;
+  icon?: string;
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  label: undefined,
+  icon: undefined,
+  disabled: false,
+});
+
+const segment = inject(segmentInjectionKey);
+if (!segment) throw new Error('BaseSegmentButton must be used within BaseSegment');
+
+const slots = useSlots();
+const el = ref<HTMLElement>();
+
+onMounted(() => {
+  if (el.value) segment.register(props.value, el.value, props.disabled);
+});
+
+onBeforeUnmount(() => segment.unregister(props.value));
+
+watch(() => props.disabled, v => segment.setDisabled(props.value, v));
+
+const isActive = computed(() => segment.isActive(props.value));
+const tabIndex = computed(() => segment.getTabIndex(props.value, props.disabled));
+
+function onClick() {
+  if (props.disabled || segment.disabled.value) return;
+  segment.select(props.value);
+}
+
+const iconOnly = computed(() => !props.label && !slots.default);
+const ariaLabel = computed(() => (iconOnly.value ? String(props.value) : undefined));
+
+const cls = computed(() => [
+  styles.item,
+  styles[segment.size],
+  styles[`mode_${segment.mode}`],
+  styles[`variant_${segment.variant}`],
+  isActive.value && styles.active,
+  (segment.disabled.value || props.disabled) && styles.disabled,
+  segment.readonly.value && styles.readonly,
+  iconOnly.value && styles.iconOnly,
+]);
+</script>
+
+<template>
+  <button
+    ref="el"
+    :class="cls"
+    :role="segment.multiple ? 'button' : 'radio'"
+    :aria-pressed="segment.multiple ? String(isActive) : undefined"
+    :aria-checked="!segment.multiple ? String(isActive) : undefined"
+    :aria-disabled="(segment.disabled.value || props.disabled) ? 'true' : undefined"
+    :aria-label="ariaLabel"
+    :tabindex="tabIndex"
+    @click="onClick"
+  >
+    <span v-if="icon" :class="styles.iconWrap">
+      <BaseIcon :name="icon" size="sm" />
+    </span>
+    <span v-if="label" :class="styles.label">{{ label }}</span>
+    <slot />
+  </button>
+</template>
+
+<style module src="./BaseSegmentButton.module.css"></style>

--- a/ui-library/components/segment/BaseSegmentContent.vue
+++ b/ui-library/components/segment/BaseSegmentContent.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed, inject, ref, watch } from 'vue';
+import { segmentInjectionKey, SegmentValue } from './BaseSegment.vue';
+
+interface Props {
+  value: SegmentValue;
+  lazy?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  lazy: true,
+});
+
+const segment = inject(segmentInjectionKey);
+if (!segment) throw new Error('BaseSegmentContent must be used within BaseSegment');
+
+const shown = ref(!props.lazy);
+const isActive = computed(() => segment.isActive(props.value));
+
+watch(isActive, val => { if (val) shown.value = true; });
+</script>
+
+<template>
+  <div v-if="shown && isActive">
+    <slot />
+  </div>
+</template>

--- a/ui-library/components/segment/BaseSegmentView.vue
+++ b/ui-library/components/segment/BaseSegmentView.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue';
+import BaseSegment, { BaseSegmentProps, SegmentValue } from './BaseSegment.vue';
+import BaseSegmentContent from './BaseSegmentContent.vue';
+
+interface ContentItem {
+  value: SegmentValue;
+  vnode: () => any;
+}
+
+interface Props extends BaseSegmentProps {
+  contents?: ContentItem[];
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: SegmentValue | SegmentValue[] | null): void;
+  (e: 'change', v: SegmentValue | SegmentValue[] | null): void;
+}>();
+
+const model = ref<SegmentValue | SegmentValue[] | null>(props.modelValue ?? (props.multiple ? [] : null));
+watch(() => props.modelValue, v => (model.value = v ?? (props.multiple ? [] : null)));
+watch(model, v => emit('update:modelValue', v));
+function onChange(v: any) { emit('change', v); }
+
+const segmentProps = computed(() => {
+  const { contents: _c, ...rest } = props;
+  return rest;
+});
+</script>
+
+<template>
+  <div>
+    <BaseSegment v-bind="segmentProps" v-model="model" @change="onChange" />
+    <div>
+      <template v-if="contents && contents.length">
+        <BaseSegmentContent v-for="c in contents" :key="c.value" :value="c.value">
+          <component :is="c.vnode" />
+        </BaseSegmentContent>
+      </template>
+      <slot v-else />
+    </div>
+  </div>
+</template>

--- a/ui-library/components/segment/index.ts
+++ b/ui-library/components/segment/index.ts
@@ -1,0 +1,4 @@
+export { default as BaseSegment } from './BaseSegment.vue';
+export { default as BaseSegmentButton } from './BaseSegmentButton.vue';
+export { default as BaseSegmentContent } from './BaseSegmentContent.vue';
+export { default as BaseSegmentView } from './BaseSegmentView.vue';

--- a/ui-library/stories/Segment.stories.ts
+++ b/ui-library/stories/Segment.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { ref } from 'vue';
+import { within, userEvent } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+import { BaseSegment, BaseSegmentButton, BaseSegmentContent, BaseSegmentView } from '../components/segment';
+
+const meta: Meta<typeof BaseSegment> = {
+  title: 'Components/Segment',
+  component: BaseSegment,
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    variant: { control: 'select', options: ['primary', 'secondary', 'success', 'warning', 'info', 'error', 'outline', 'ghost'] },
+    shape: { control: 'select', options: ['pill', 'rounded'] },
+    mode: { control: 'select', options: ['ios', 'md'] },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    scrollable: { control: 'boolean' },
+    multiple: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BaseSegment>;
+
+export const Basic: Story = {
+  render: args => ({
+    components: { BaseSegment, BaseSegmentButton },
+    setup() {
+      const value = ref(args.multiple ? [] : null);
+      return { args, value };
+    },
+    template: `
+      <BaseSegment v-bind="args" v-model="value">
+        <BaseSegmentButton value="one" label="One" />
+        <BaseSegmentButton value="two" label="Two" />
+        <BaseSegmentButton value="three" label="Three" />
+      </BaseSegment>
+    `,
+  }),
+  args: {
+    size: 'md',
+    variant: 'primary',
+    shape: 'pill',
+    mode: 'md',
+    scrollable: false,
+    fullWidth: false,
+    disabled: false,
+    readonly: false,
+    multiple: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const first = await canvas.findByRole('radio', { name: 'One' });
+    await first.focus();
+    await userEvent.keyboard('{arrowright}');
+    const second = await canvas.findByRole('radio', { name: 'Two' });
+    expect(second).toHaveFocus();
+  },
+};
+
+export const View: StoryObj<typeof BaseSegmentView> = {
+  render: args => ({
+    components: { BaseSegmentView, BaseSegmentContent },
+    setup() {
+      const value = ref(args.multiple ? [] : null);
+      const items = [
+        { label: 'One', value: 'one' },
+        { label: 'Two', value: 'two' },
+        { label: 'Three', value: 'three' },
+      ];
+      return { args, value, items };
+    },
+    template: `
+      <BaseSegmentView v-bind="args" v-model="value" :items="items">
+        <BaseSegmentContent value="one">First content</BaseSegmentContent>
+        <BaseSegmentContent value="two">Second content</BaseSegmentContent>
+        <BaseSegmentContent value="three">Third content</BaseSegmentContent>
+      </BaseSegmentView>
+    `,
+  }),
+  args: {
+    size: 'md',
+    variant: 'primary',
+    shape: 'pill',
+    mode: 'md',
+  },
+};


### PR DESCRIPTION
## Summary
- add BaseSegment container with animated indicator, keyboard navigation and form support
- provide BaseSegmentButton, BaseSegmentContent and BaseSegmentView helpers
- document new segment suite and add basic tests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Playwright browser binaries missing; attempted install but download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a031c3d7ec8321b4cbb1ee9bb9036b